### PR TITLE
Automatically size charts based upon the canvas size.

### DIFF
--- a/Chart.js
+++ b/Chart.js
@@ -39,6 +39,11 @@
 
 		var width = this.width = computeDimension(context.canvas,'Width');
 		var height = this.height = computeDimension(context.canvas,'Height');
+
+		// Firefox requires this to work correctly
+		context.canvas.width  = width;
+		context.canvas.height = height;
+
 		this.aspectRatio = this.width / this.height;
 		//High pixel density displays - multiply the size of the canvas height/width by the device pixel ratio, then scale.
 		helpers.retinaScale(this);

--- a/Chart.js
+++ b/Chart.js
@@ -25,8 +25,20 @@
 		this.ctx = context;
 
 		//Variables global to the chart
-		var width = this.width = context.canvas.width;
-		var height = this.height = context.canvas.height;
+		var computeDimension = function(element,dimension)
+		{
+			if (element['offset'+dimension])
+			{
+				return element['offset'+dimension];
+			}
+			else
+			{
+				return document.defaultView.getComputedStyle(element).getPropertyValue(dimension);
+			}
+		}
+
+		var width = this.width = computeDimension(context.canvas,'Width');
+		var height = this.height = computeDimension(context.canvas,'Height');
 		this.aspectRatio = this.width / this.height;
 		//High pixel density displays - multiply the size of the canvas height/width by the device pixel ratio, then scale.
 		helpers.retinaScale(this);


### PR DESCRIPTION
This allows charts to be drawn to the canvas's current size, wether this be automatically determined through css
or through manually sizing the canvas, you can't rely on the canvas reported size as it defaults to a imo silly size.

Note I recompressed the js with this fix but as there was no noted preferred build chain I used uglifier which I had
to hand. Hence the change.