### PR TITLE
Allow custom padding on line charts

### DIFF
--- a/docs/01-Line-Chart.md
+++ b/docs/01-Line-Chart.md
@@ -96,6 +96,9 @@ These are the customisation options specific to Line charts. These options are m
 	//String - A legend template
 	legendTemplate : "<ul class=\"<%=name.toLowerCase()%>-legend\"><% for (var i=0; i<datasets.length; i++){%><li><span style=\"background-color:<%=datasets[i].lineColor%>\"></span><%if(datasets[i].label){%><%=datasets[i].label%><%}%></li><%}%></ul>"
 	{% endraw %}
+	
+	//Number - how much padding there is around the chart
+	padding: 0
 };
 ```
 

--- a/src/Chart.Line.js
+++ b/src/Chart.Line.js
@@ -195,7 +195,7 @@
 				lineColor : this.options.scaleLineColor,
 				gridLineWidth : (this.options.scaleShowGridLines) ? this.options.scaleGridLineWidth : 0,
 				gridLineColor : (this.options.scaleShowGridLines) ? this.options.scaleGridLineColor : "rgba(0,0,0,0)",
-				padding: (this.options.showScale) ? 0 : this.options.pointDotRadius + this.options.pointDotStrokeWidth,
+				padding: (!isNaN(this.options.padding)) ? this.options.padding : (this.options.showScale) ? 0 : this.options.pointDotRadius + this.options.pointDotStrokeWidth,
 				showLabels : this.options.scaleShowLabels,
 				display : this.options.showScale
 			};


### PR DESCRIPTION
I needed to have a sort of "edge-to-edge" effect for a chart and despite removing the scale there was still some padding related to the tooltips.

This allows a "padding" option that can be used to make the actual data fill the whole width or of course to add additional padding if desired.