### PR TITLE
Fix error when canvas has width or height of 0

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -25,8 +25,8 @@
 		this.ctx = context;
 
 		//Variables global to the chart
-		var width = this.width = context.canvas.width;
-		var height = this.height = context.canvas.height;
+		var width = this.width = context.canvas.width || 1;
+		var height = this.height = context.canvas.height || 1;
 		this.aspectRatio = this.width / this.height;
 		//High pixel density displays - multiply the size of the canvas height/width by the device pixel ratio, then scale.
 		helpers.retinaScale(this);
@@ -411,7 +411,7 @@
 			 	{
 			 	return templateString(valuesObject);
 			 	}
-			 
+
 			var cache = {};
 			function tmpl(str, data){
 				// Figure out if we're getting a template, or if we need to


### PR DESCRIPTION
At Brigade, we are using Chart.js to render some charts that are
dynamically sized to the dimensions of the canvas on initialization. In
normal browser scenarios this worked great, but in our Jasmine tests we
ran into the following error:

> Uncaught IndexSizeError: Failed to execute 'arc' on
> 'CanvasRenderingContext2D': The radius provided (-0.5) is negative.

This was happening because in the Jasmine testing context, the canvas
was invisible and therefore had a height and width of 0.

To fix this, we thought it made sense to default the width and height of
the Chart to 1 if it was falsey. This also prevents a division by 0 from
happening on the following line. We had considered using `Math.max`
instead, which would also protect against negative numbers, but that
feels a bit YAGNI at this point.

This is perhaps against the philosophy of failing hard and fast, but it
seems like enough of an edge case as to not really matter. Also, if the
intention is to fail hard and fast, this could be done with as a check
for acceptable values and a `throw` statement if the check is not
satisfied.

While I was in there, I removed some incidental trailing whitespace.