### PR TITLE
Fix legendTemplate example to use strokeColor

### DIFF
--- a/docs/01-Line-Chart.md
+++ b/docs/01-Line-Chart.md
@@ -94,7 +94,7 @@ These are the customisation options specific to Line charts. These options are m
 	datasetFill : true,
 	{% raw %}
 	//String - A legend template
-	legendTemplate : "<ul class=\"<%=name.toLowerCase()%>-legend\"><% for (var i=0; i<datasets.length; i++){%><li><span style=\"background-color:<%=datasets[i].lineColor%>\"></span><%if(datasets[i].label){%><%=datasets[i].label%><%}%></li><%}%></ul>"
+	legendTemplate : "<ul class=\"<%=name.toLowerCase()%>-legend\"><% for (var i=0; i<datasets.length; i++){%><li><span style=\"background-color:<%=datasets[i].strokeColor%>\"></span><%if(datasets[i].label){%><%=datasets[i].label%><%}%></li><%}%></ul>"
 	{% endraw %}
 };
 ```


### PR DESCRIPTION
fixed legendTemplate example to use strokeColor instead of non-functional lineColor.