### PR TITLE
Fixed issue regarding Bar charts and negative values.

### DIFF
--- a/Chart.js
+++ b/Chart.js
@@ -1204,7 +1204,8 @@
 				leftX = this.x - halfWidth,
 				rightX = this.x + halfWidth,
 				top = this.base - (this.base - this.y),
-				halfStroke = this.strokeWidth / 2;
+				halfStroke = this.strokeWidth / 2,
+				endPoint = this.scale.calculateY(0);
 
 			// Canvas doesn't allow us to stroke inside the width so we can
 			// adjust the sizes to fit if we're setting a stroke on the line
@@ -1222,10 +1223,10 @@
 
 			// It'd be nice to keep this class totally generic to any rectangle
 			// and simply specify which border to miss out.
-			ctx.moveTo(leftX, this.base);
+			ctx.moveTo(leftX, endPoint);
 			ctx.lineTo(leftX, top);
 			ctx.lineTo(rightX, top);
-			ctx.lineTo(rightX, this.base);
+			ctx.lineTo(rightX, endPoint);
 			ctx.fill();
 			if (this.showStroke){
 				ctx.stroke();
@@ -2065,12 +2066,13 @@
 			this.buildScale(data.labels);
 
 			this.BarClass.prototype.base = this.scale.endPoint;
+			this.BarClass.prototype.scale = this.scale;
 
 			this.eachBars(function(bar, index, datasetIndex){
 				helpers.extend(bar, {
 					width : this.scale.calculateBarWidth(this.datasets.length),
 					x: this.scale.calculateBarX(this.datasets.length, datasetIndex, index),
-					y: this.scale.endPoint
+					y: this.scale.calculateY(0)
 				});
 				bar.save();
 			}, this);

--- a/samples/bar.html
+++ b/samples/bar.html
@@ -21,14 +21,14 @@
 				strokeColor : "rgba(220,220,220,0.8)",
 				highlightFill: "rgba(220,220,220,0.75)",
 				highlightStroke: "rgba(220,220,220,1)",
-				data : [randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor()]
+				data : [randomScalingFactor()*-1,randomScalingFactor(),randomScalingFactor()*-1,randomScalingFactor(),randomScalingFactor()*-1,randomScalingFactor(),randomScalingFactor()*-1]
 			},
 			{
 				fillColor : "rgba(151,187,205,0.5)",
 				strokeColor : "rgba(151,187,205,0.8)",
 				highlightFill : "rgba(151,187,205,0.75)",
 				highlightStroke : "rgba(151,187,205,1)",
-				data : [randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor()]
+				data : [randomScalingFactor(),randomScalingFactor()*-1,randomScalingFactor(),randomScalingFactor()*-1,randomScalingFactor(),randomScalingFactor()*-1,randomScalingFactor()]
 			}
 		]
 
@@ -36,7 +36,8 @@
 	window.onload = function(){
 		var ctx = document.getElementById("canvas").getContext("2d");
 		window.myBar = new Chart(ctx).Bar(barChartData, {
-			responsive : true
+			responsive : true,
+			scaleBeginAtZero : false
 		});
 	}
 


### PR DESCRIPTION
This pull request should fix problem with Bar charts having negative values in its datasets.

I've also updated the example samples/bar.html for a demonstration of the fix.

When wanting to make use of this feature it's important to set the option scaleBeginAtZero to false:

```javascript
new Chart(ctx).Bar(barChartData, {
  scaleBeginAtZero : false
});
```