### PR TITLE
add 10 to yLabelWidth on set, rather than on use

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -1411,7 +1411,7 @@
 			for (var i=0; i<=this.steps; i++){
 				this.yLabels.push(template(this.templateString,{value:(this.min + (i * this.stepValue)).toFixed(stepDecimalPlaces)}));
 			}
-			this.yLabelWidth = (this.display && this.showLabels) ? longestText(this.ctx,this.font,this.yLabels) : 0;
+			this.yLabelWidth = (this.display && this.showLabels) ? longestText(this.ctx,this.font,this.yLabels) + 10 : 0;
 		},
 		addXLabel : function(label){
 			this.xLabels.push(label);
@@ -1484,7 +1484,7 @@
 
 
 			this.xScalePaddingRight = lastWidth/2 + 3;
-			this.xScalePaddingLeft = (firstWidth/2 > this.yLabelWidth + 10) ? firstWidth/2 : this.yLabelWidth + 10;
+			this.xScalePaddingLeft = (firstWidth/2 > this.yLabelWidth) ? firstWidth/2 : this.yLabelWidth;
 
 			this.xLabelRotation = 0;
 			if (this.display){
@@ -1503,7 +1503,7 @@
 					lastRotated = cosRotation * lastWidth;
 
 					// We're right aligning the text now.
-					if (firstRotated + this.fontSize / 2 > this.yLabelWidth + 8){
+					if (firstRotated + this.fontSize / 2 > this.yLabelWidth){
 						this.xScalePaddingLeft = firstRotated + this.fontSize / 2;
 					}
 					this.xScalePaddingRight = this.fontSize/2;


### PR DESCRIPTION
Padding on the line chart's y-axis labels can get crowded because when checking the x-axis label rotation (line 1506) it checks for `this.yLabelWidth + 8` rather than `this.yLabelWidth + 10`.
Ex:
![screen shot 2014-10-08 at 11 38 08](https://cloud.githubusercontent.com/assets/2278079/4562069/cc7e411a-4f01-11e4-97d3-9979ef334120.png)

Changing this check to `yLabelWidth + 10` fixes this issue.  However, since the `yLabelWidth` variable is either used to only check against itself (in the `fit()` method, lines 1462 & 1468), or checking against `yLabelWidth + 10` (line 1487 * 2, line 1506), I moved the addition to the setting of `yLabelWidth`, rather than when checking the variable.

Result:
![screen shot 2014-10-08 at 11 52 47](https://cloud.githubusercontent.com/assets/2278079/4562265/37381944-4f03-11e4-9f43-9e397055a442.png)

The result is correctly padded y-axis labels.