### PR TITLE
Update Chart.Bar.js to cater to an array of colours for fillColor

### DIFF
--- a/src/Chart.Bar.js
+++ b/src/Chart.Bar.js
@@ -110,7 +110,7 @@
 						label : data.labels[index],
 						datasetLabel: dataset.label,
 						strokeColor : dataset.strokeColor,
-						fillColor : dataset.fillColor,
+						fillColor : (dataset.fillColor instanceof Array) ? dataset.fillColor[index] : dataset.fillColor,
 						highlightFill : dataset.highlightFill || dataset.fillColor,
 						highlightStroke : dataset.highlightStroke || dataset.strokeColor
 					}));


### PR DESCRIPTION
Change to line 113 - allows for the passing of an array of fill colours to the the bar chart or a single colour (the current implementation)
Possible modification is to make the index into the fill color array the mod of the length of the array so that the colour array does not have to match the number of labels.