### PR TITLE
Ensure that scales for polar area graphs are regenerated on updates.

### DIFF
--- a/src/Chart.PolarArea.js
+++ b/src/Chart.PolarArea.js
@@ -195,6 +195,8 @@
 			helpers.each(this.segments,function(segment){
 				segment.save();
 			});
+			
+			this.reflow();
 			this.render();
 		},
 		reflow : function(){


### PR DESCRIPTION
Fix for [#618](https://github.com/nnnick/Chart.js/issues/618). Implemented in the same style as the radar chart even though in some cases reflow() is called twice. This occurs, for example, in addData