### PR TITLE
Only build scale and calculate x,y values once on init and fix linting.

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -238,7 +238,7 @@
 				if (filterCallback(currentItem)){
 					return currentItem;
 				}
-			};
+			}
 		},
 		findPreviousWhere = helpers.findPreviousWhere = function(arrayToSearch, filterCallback, startIndex){
 			// Default to end of the array
@@ -250,7 +250,7 @@
 				if (filterCallback(currentItem)){
 					return currentItem;
 				}
-			};
+			}
 		},
 		inherits = helpers.inherits = function(extensions){
 			//Basic javascript inheritance based on the model created in Backbone.js

--- a/src/Chart.Line.js
+++ b/src/Chart.Line.js
@@ -109,20 +109,17 @@
 						highlightStroke : dataset.pointHighlightStroke || dataset.pointStrokeColor
 					}));
 				},this);
-
-				this.buildScale(data.labels);
-
-
-				this.eachPoints(function(point, index){
-					helpers.extend(point, {
-						x: this.scale.calculateX(index),
-						y: this.scale.endPoint
-					});
-					point.save();
-				}, this);
-
 			},this);
 
+			this.buildScale(data.labels);
+
+			this.eachPoints(function(point, index){
+				helpers.extend(point, {
+					x: this.scale.calculateX(index),
+					y: this.scale.endPoint
+				});
+				point.save();
+			}, this);
 
 			this.render();
 		},


### PR DESCRIPTION
Building of scale and calculating x,y values for each point was done after each added datasetObject, causing a quadratic complexity. Improves initialization performance and fixes linting.