### PR TITLE
Added a thousand-divider that works with a modern version of Chart.js.

### DIFF
--- a/Chart.js
+++ b/Chart.js
@@ -21,6 +21,7 @@
 	var Chart = function(context){
 		var chart = this;
 		this.canvas = context.canvas;
+		this.int_language = "en_EN";
 
 		this.ctx = context;
 
@@ -33,6 +34,11 @@
 
 		return this;
 	};
+
+	// Will convert a given variable into a int or float if it's a string and return a locale-separated value.
+	// Wasn't sure where to put this as this code is massive and not well separated for new eyes. Put it w/e.
+	function thousand_divider(integer) { return parseFloat(integer).toLocaleString(Chart.int_language); };
+
 	//Globally expose the defaults to allow for user updating/changing
 	Chart.defaults = {
 		global: {
@@ -1565,7 +1571,8 @@
 					ctx.textAlign = "right";
 					ctx.textBaseline = "middle";
 					if (this.showLabels){
-						ctx.fillText(labelString,xStart - 10,yLabelCenter);
+						//ctx.fillText(labelString,xStart - 10,yLabelCenter);
+						ctx.fillText(thousand_divider(labelString), xStart - 5, yLabelCenter);
 					}
 					ctx.beginPath();
 					if (index > 0){


### PR DESCRIPTION
Much to my surprise, this isn't default configuration. I haven't bothered making it so either this time because quite frankly it should be default.. It's impossible to read large-scale data with this library unless you separate the numbers.