### PR TITLE
prevent divide by zero error when calculating a circumference

### DIFF
--- a/src/Chart.Doughnut.js
+++ b/src/Chart.Doughnut.js
@@ -108,8 +108,12 @@
 				this.update();
 			}
 		},
-		calculateCircumference : function(value){
-			return (Math.PI*2)*(value / this.total);
+		calculateCircumference : function(value) {
+			if ( this.total > 0 ) {
+				return (Math.PI*2)*(value / this.total);
+			} else {
+				return 0;
+			}
 		},
 		calculateTotal : function(data){
 			this.total = 0;


### PR DESCRIPTION
If you have a pie chart then update all the segments to zero then update it breaks any further updates to the segments. It was a divide by zero issue, no big deal. This merge will close issue #661 