### PR TITLE
Don't show tooltips with empty text

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -1318,6 +1318,9 @@
 
 	Chart.MultiTooltip = Chart.Element.extend({
 		initialize : function(){
+			
+			if(!this.text) return;
+			
 			this.font = fontString(this.fontSize,this.fontStyle,this.fontFamily);
 
 			this.titleFont = fontString(this.titleFontSize,this.titleFontStyle,this.titleFontFamily);


### PR DESCRIPTION
The dev can make a template that return an empty string. In that case there is no need to show the tooltip.

https://github.com/nnnick/Chart.js/pull/823