### PR TITLE
Destroy needs to reset the canvas to original size

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -866,6 +866,16 @@
 			return template(this.options.legendTemplate,this);
 		},
 		destroy : function(){
+			// If we scaled for a retina screen, undo that action here
+			if (window.devicePixelRatio) {
+				var ctx = this.chart.ctx,
+				width = this.chart.canvas.width,
+				height = this.chart.canvas.height;
+				ctx.canvas.height = height / window.devicePixelRatio;
+				ctx.canvas.width = width / window.devicePixelRatio;
+				ctx.scale(1 / window.devicePixelRatio, 1 / window.devicePixelRatio);
+			}
+		
 			this.clear();
 			unbindEvents(this, this.events);
 			delete Chart.instances[this.id];


### PR DESCRIPTION
This is a fix for #713 
[JSBin](http://jsbin.com/zeniwu/1/edit?html,js,output) of the solution in action

Tested on:
Win7 x64: Firefox 34.0.5, Chrome 39.0.2171.95
Android 5.0.1 (Nexus 5) Chrome 39.0.2171.93
iOS 8.1.2 (iPad 3 retina) Safari 8 build 600.1.4 