### PR TITLE
Restore original canvas context when destroying

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -868,6 +868,21 @@
 		destroy : function(){
 			this.clear();
 			unbindEvents(this, this.events);
+			var canvas = this.chart.canvas;
+
+			// Reset canvas height/width attributes starts a fresh with the canvas context
+			canvas.width = this.chart.width;
+			canvas.height = this.chart.height;
+
+			// < IE9 doesn't support removeProperty
+			if (canvas.style.removeProperty) {
+				canvas.style.removeProperty('width');
+				canvas.style.removeProperty('height');
+			} else {
+				canvas.style.removeAttribute('width');
+				canvas.style.removeAttribute('height');
+			}
+
 			delete Chart.instances[this.id];
 		},
 		showTooltip : function(ChartElements, forceRedraw){


### PR DESCRIPTION
Fixes #713 

Inspired by the work done in #847 but addresses the use case of resetting CSS width/height regardless of whether we have a `devicePixelRatio` or not.

By setting the width/height of the canvas itself, the spec says it should completely reset any of the state applied to the canvas context.

Section 4.8.11:

> When the canvas element is created, and subsequently whenever the width and height attributes are set (whether to a new value or to the previous value), the bitmap and any associated contexts must be cleared back to their initial state and reinitialized with the newly specified coordinate space dimensions.