### PR TITLE
Fix issue with "Illegal invocation" in cancelAnimFrame.

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -825,7 +825,7 @@
 		},
 		stop : function(){
 			// Stops any current animation loop occuring
-			helpers.cancelAnimFrame.call(root, this.animationFrame);
+			helpers.cancelAnimFrame(this.animationFrame);
 			return this;
 		},
 		resize : function(callback){


### PR DESCRIPTION
Fixes issue #434 where "Uncaught TypeError: Illegal invocation" is thrown when using chart.js with browserify. The issue seems to be that `this` is not set to `window` at the start, so `root` will not be set to `window`, and so `cancelAnimFrame` is called on with the wrong `thisArg`.

According to the comments in the code `root` is used since it will be set to `global` when used in node, where `window` does not exist. `cancelAnimFrame` uses `window` regardless, and animation frames don't seem to make much sense in node regardless.