### PR TITLE
Show x labels

### DIFF
--- a/docs/01-Line-Chart.md
+++ b/docs/01-Line-Chart.md
@@ -57,8 +57,7 @@ These are the customisation options specific to Line charts. These options are m
 ```javascript
 {
 
-	//Boolean or Number - Number of labels to be shown on X-Axis. false: no label displayed, true: all labels
-	displayed, 10: only 10 labels displayed
+//Boolean or Number - Number of labels to be shown on X-Axis. false: no label displayed, true: all labels displayed, 10: only 10 labels displayed
 	showXLabels: 10,
 
 	///Boolean - Whether grid lines are shown across the chart

--- a/docs/01-Line-Chart.md
+++ b/docs/01-Line-Chart.md
@@ -57,6 +57,10 @@ These are the customisation options specific to Line charts. These options are m
 ```javascript
 {
 
+	//Boolean or Number - Number of labels to be shown on X-Axis. false: no label displayed, true: all labels
+	displayed, 10: only 10 labels displayed
+	showXLabels: 10,
+
 	///Boolean - Whether grid lines are shown across the chart
 	scaleShowGridLines : true,
 

--- a/docs/02-Bar-Chart.md
+++ b/docs/02-Bar-Chart.md
@@ -53,6 +53,10 @@ These are the customisation options specific to Bar charts. These options are me
 
 ```javascript
 {
+	//Boolean or Number - Number of labels to be shown on X-Axis. false: no label displayed, true: all labels
+	displayed, 10: only 10 labels displayed
+	showXLabels: 10,
+
 	//Boolean - Whether the scale should start at zero, or an order of magnitude down from the lowest value
 	scaleBeginAtZero : true,
 

--- a/docs/02-Bar-Chart.md
+++ b/docs/02-Bar-Chart.md
@@ -53,8 +53,7 @@ These are the customisation options specific to Bar charts. These options are me
 
 ```javascript
 {
-	//Boolean or Number - Number of labels to be shown on X-Axis. false: no label displayed, true: all labels
-	displayed, 10: only 10 labels displayed
+	//Boolean or Number - Number of labels to be shown on X-Axis. false: no label displayed, true: all labels displayed, 10: only 10 labels displayed
 	showXLabels: 10,
 
 	//Boolean - Whether the scale should start at zero, or an order of magnitude down from the lowest value

--- a/src/Chart.Bar.js
+++ b/src/Chart.Bar.js
@@ -208,6 +208,7 @@
 					);
 					helpers.extend(this, updatedRanges);
 				},
+				showXLabels: (this.options.showXLabels) ? this.options.showXLabels : true,
 				xLabels : labels,
 				font : helpers.fontString(this.options.scaleFontSize, this.options.scaleFontStyle, this.options.scaleFontFamily),
 				lineWidth : this.options.scaleLineWidth,

--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -68,6 +68,9 @@
 			// Boolean - Whether to show labels on the scale
 			scaleShowLabels: true,
 
+			// Boolean or a positive integer denoting number of labels to be shown on x axis
+			showXLabels: true,
+
 			// Interpolated JS string - can access value
 			scaleLabel: "<%=value%>",
 
@@ -1644,6 +1647,9 @@
 
 				},this);
 
+				// if showXLabels is a number then divide and determine how many xLabels to skip before showing next label
+				// else, if showXLabels is true, print all labels, else never print
+				this.xLabelsSkipper = isNumber(this.showXLabels) ? Math.ceil(this.xLabels.length/this.showXLabels) : (this.showXLabels === true) ? 1 : this.xLabels.length+1;
 				each(this.xLabels,function(label,index){
 					var xPos = this.calculateX(index) + aliasPixel(this.lineWidth),
 						// Check to see if line/bar here and decide where to place the line
@@ -1695,7 +1701,9 @@
 					ctx.font = this.font;
 					ctx.textAlign = (isRotated) ? "right" : "center";
 					ctx.textBaseline = (isRotated) ? "middle" : "top";
-					ctx.fillText(label, 0, 0);
+					if(index % this.xLabelsSkipper === 0) {
+						ctx.fillText(label, 0, 0);
+					}
 					ctx.restore();
 				},this);
 

--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -1689,12 +1689,14 @@
 
 
 					// Small lines at the bottom of the base grid line
-					ctx.beginPath();
-					ctx.moveTo(linePos,this.endPoint);
-					ctx.lineTo(linePos,this.endPoint + 5);
-					ctx.stroke();
-					ctx.closePath();
-
+					if(index % this.xLabelsSkipper === 0) {
+						//X axis ticks only painted for number of selected x values
+						ctx.beginPath();
+						ctx.moveTo(linePos,this.endPoint);
+						ctx.lineTo(linePos,this.endPoint + 5);
+						ctx.stroke();
+						ctx.closePath();
+					}
 					ctx.save();
 					ctx.translate(xPos,(isRotated) ? this.endPoint + 12 : this.endPoint + 8);
 					ctx.rotate(toRadians(this.xLabelRotation)*-1);

--- a/src/Chart.Line.js
+++ b/src/Chart.Line.js
@@ -192,6 +192,7 @@
 					);
 					helpers.extend(this, updatedRanges);
 				},
+				showXLabels: (this.options.showXLabels) ? this.options.showXLabels : true,
 				xLabels : labels,
 				font : helpers.fontString(this.options.scaleFontSize, this.options.scaleFontStyle, this.options.scaleFontFamily),
 				lineWidth : this.options.scaleLineWidth,


### PR DESCRIPTION
Applicable to bar chart and line chart.

User can now pass a { showXLabels: 10 } to display only 10 labels (actual displayed labels count might be a bit different depending on the number of total labels present on x axis, but it will still remain close to 10 however)

Helps a lot when there is a very large amount of data. Earlier, the graph used to look devastated due to x axis labels drawn over each other in the cramped space. With showXLabels, user now has the control to reduce the number of labels to whatever number of labels fit good into the space available to him.

Please see the attached images for a comparison. the second graph has been passed { showXLabels: 10 } into option.

Without showXLabels:
![without showXLabels: crowded](https://cloud.githubusercontent.com/assets/2913409/5914618/f7b47330-a61e-11e4-93ce-4c66b1608ee6.png)

With showXLabels = 10:
![with showXLabels: 10](https://cloud.githubusercontent.com/assets/2913409/5914627/07a325de-a61f-11e4-9710-5ee54504ea9e.png)

Usage: Just pass showXLabels: 10 along with other options in the constructor. 
Example:
myLine = new Chart(ctx).Line(lineChartData, {
	responsive: true,
	showXLabels: 10
});

