### PR TITLE
Fix a divide by 0 error when there is only 1 label

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -1575,7 +1575,7 @@
 			var isRotated = (this.xLabelRotation > 0),
 				// innerWidth = (this.offsetGridLines) ? this.width - offsetLeft - this.padding : this.width - (offsetLeft + halfLabelWidth * 2) - this.padding,
 				innerWidth = this.width - (this.xScalePaddingLeft + this.xScalePaddingRight),
-				valueWidth = innerWidth/(this.valuesCount - ((this.offsetGridLines) ? 0 : 1)),
+				valueWidth = innerWidth/Math.max((this.valuesCount - ((this.offsetGridLines) ? 0 : 1)), 1),
 				valueOffset = (valueWidth * index) + this.xScalePaddingLeft;
 
 			if (this.offsetGridLines){


### PR DESCRIPTION
Replaces #702 since I screwed up the rebase. @fulldecent this should be easier to merge.