### PR TITLE
Fix regression for cancelAnimFrame

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -825,7 +825,7 @@
 		},
 		stop : function(){
 			// Stops any current animation loop occuring
-			helpers.cancelAnimFrame(this.animationFrame);
+			helpers.cancelAnimFrame.call(window, this.animationFrame);
 			return this;
 		},
 		resize : function(callback){


### PR DESCRIPTION
Fixed regression after PR #889 - make sure execution context is window when canceling an animation frame.

This time actually verified that samples work, and tested with a simple browserify sample to make sure it still solves the browserify issue.