### PR TITLE
Implement ability to use arrays for bar chart styling options (fixed #921)

### DIFF
--- a/docs/02-Bar-Chart.md
+++ b/docs/02-Bar-Chart.md
@@ -42,7 +42,7 @@ var data = {
 	]
 };
 ```
-The bar chart has the a very similar data structure to the line chart, and has an array of datasets, each with colours and an array of data. Again, colours are in CSS format.
+The bar chart has the a very similar data structure to the line chart, and has an array of datasets, each with colours and an array of data. The style options -- fillColor, strokeColor, highlightFill, and highlightStroke -- can also be arrays, depending on which of the bars you want unique styling for. For example, if you want each data point to have a different fill color, but the other style options to be the same for each bar in that dataset, simply give fillColor an array, one entry per data point. Again, colours are in CSS format.
 We have an array of labels too for display. In the example, we are showing the same data as the previous line chart example.
 
 The label key on each dataset is optional, and can be used when generating a scale for the chart.

--- a/src/Chart.Bar.js
+++ b/src/Chart.Bar.js
@@ -102,8 +102,8 @@
 
 				var datasetObject = {
 					label : dataset.label || null,
-					fillColor : dataset.fillColor,
-					strokeColor : dataset.strokeColor,
+					fillColor : helpers.nthOrIdentity(dataset.fillColor, datasetIndex),
+					strokeColor : helpers.nthOrIdentity(dataset.strokeColor, datasetIndex),
 					bars : []
 				};
 
@@ -115,10 +115,12 @@
 						value : dataPoint,
 						label : data.labels[index],
 						datasetLabel: dataset.label,
-						strokeColor : dataset.strokeColor,
-						fillColor : dataset.fillColor,
-						highlightFill : dataset.highlightFill || dataset.fillColor,
-						highlightStroke : dataset.highlightStroke || dataset.strokeColor
+						strokeColor : helpers.nthOrIdentity(dataset.strokeColor, index),
+						fillColor : helpers.nthOrIdentity(dataset.fillColor, index),
+						highlightFill : helpers.nthOrIdentity(dataset.highlightFill, index) ||
+										helpers.nthOrIdentity(dataset.fillColor, index),
+						highlightStroke : helpers.nthOrIdentity(dataset.highlightStroke, index) ||
+											helpers.nthOrIdentity(dataset.strokeColor, index),
 					}));
 				},this);
 

--- a/src/Chart.Bar.js
+++ b/src/Chart.Bar.js
@@ -117,10 +117,8 @@
 						datasetLabel: dataset.label,
 						strokeColor : helpers.nthOrIdentity(dataset.strokeColor, index),
 						fillColor : helpers.nthOrIdentity(dataset.fillColor, index),
-						highlightFill : helpers.nthOrIdentity(dataset.highlightFill, index) ||
-										helpers.nthOrIdentity(dataset.fillColor, index),
-						highlightStroke : helpers.nthOrIdentity(dataset.highlightStroke, index) ||
-											helpers.nthOrIdentity(dataset.strokeColor, index),
+						highlightFill : helpers.nthOrIdentity((dataset.highlightFill || dataset.fillColor), index),
+						highlightStroke : helpers.nthOrIdentity((dataset.highlightStroke || dataset.strokeColor), index),
 					}));
 				},this);
 

--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -272,6 +272,10 @@
 
 			return ChartElement;
 		},
+		nthOrIdentity = helpers.nthOrIdentity = function(potentialArray, nthIndex){
+			// Return the nth item if potentialArray is an array, else return potentialArray
+			return (potentialArray.constructor === Array) ?  potentialArray[nthIndex] : potentialArray;
+		},
 		noop = helpers.noop = function(){},
 		uid = helpers.uid = (function(){
 			var id=0;

--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -272,9 +272,14 @@
 
 			return ChartElement;
 		},
+		isArray = helpers.isArray = Array.isArray || function(potentialArray){
+			// Array.isArray is the only 'correct' solution, but not all browsers will have this,
+			// so here's a shim. Influenced by underscore.js
+			return potentialArray.constructor === 'Array';
+		},
 		nthOrIdentity = helpers.nthOrIdentity = function(potentialArray, nthIndex){
 			// Return the nth item if potentialArray is an array, else return potentialArray
-			return (potentialArray.constructor === Array) ?  potentialArray[nthIndex] : potentialArray;
+			return isArray(potentialArray) ? potentialArray[nthIndex] : potentialArray;
 		},
 		noop = helpers.noop = function(){},
 		uid = helpers.uid = (function(){


### PR DESCRIPTION
I have enabled the use of arrays for the styling options in datasets, while maintaining the ability to use scalars as well.

I made two helper functions, isArray and nthOrIdentity, the first to lower the verbosity for array type checking, and the second to grab the nth item in the passed in potential array, or to return said potential array if it is not, in fact, an array.

I've updated src/Chart.Bar.js to use nthOrIdentity when styling the bars, as well as adding to the documentation about bar charts to explain this new functionality.

This is along the same lines as #681, but broader and potentially more robust.