### PR TITLE
added fix for issues/934

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -825,7 +825,7 @@
 		},
 		stop : function(){
 			// Stops any current animation loop occuring
-			helpers.cancelAnimFrame(this.animationFrame);
+			helpers.cancelAnimFrame.call(window,this.animationFrame);
 			return this;
 		},
 		resize : function(callback){
@@ -1260,7 +1260,7 @@
 			return this.base - this.y;
 		},
 		inRange : function(chartX,chartY){
-			return (chartX >= this.x - this.width/2 && chartX <= this.x + this.width/2) && (chartY >= this.y && chartY <= this.base);
+			return (chartX >= this.x - this.width/2 && chartX <= this.x + this.width/2) && (chartY >= this.y && (chartY <= this.base || chartY > this.base));
 		}
 	});
 

--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -1260,7 +1260,7 @@
 			return this.base - this.y;
 		},
 		inRange : function(chartX,chartY){
-			return (chartX >= this.x - this.width/2 && chartX <= this.x + this.width/2) && (chartY >= this.y && (chartY <= this.base || chartY > this.base));
+			return (chartX >= this.x - this.width/2 && chartX <= this.x + this.width/2) && chartY >= this.y;
 		}
 	});
 


### PR DESCRIPTION
nnnick/Chart.js#934, bars charts now have the same behaviour as line charts where the label can also act as a triggering point for the tooltip to show.

This gets around the issue of not being able to see the tooltip for bars where the scale is huge.