### PR TITLE
Multicolored Bar Charts in Same Dataset

### DIFF
--- a/Chart.js
+++ b/Chart.js
@@ -25,25 +25,8 @@
 		this.ctx = context;
 
 		//Variables global to the chart
-		var computeDimension = function(element,dimension)
-		{
-			if (element['offset'+dimension])
-			{
-				return element['offset'+dimension];
-			}
-			else
-			{
-				return document.defaultView.getComputedStyle(element).getPropertyValue(dimension);
-			}
-		}
-
-		var width = this.width = computeDimension(context.canvas,'Width');
-		var height = this.height = computeDimension(context.canvas,'Height');
-
-		// Firefox requires this to work correctly
-		context.canvas.width  = width;
-		context.canvas.height = height;
-
+		var width = this.width = context.canvas.width;
+		var height = this.height = context.canvas.height;
 		this.aspectRatio = this.width / this.height;
 		//High pixel density displays - multiply the size of the canvas height/width by the device pixel ratio, then scale.
 		helpers.retinaScale(this);
@@ -2131,15 +2114,18 @@
 				this.datasets.push(datasetObject);
 
 				helpers.each(dataset.data,function(dataPoint,index){
+					var highlightFill = dataset.highlightFill || dataset.fillColor;
+					var highlightStroke = dataset.highlightStroke || dataset.strokeColor;
+
 					//Add a new point for each piece of data, passing any required data to draw.
 					datasetObject.bars.push(new this.BarClass({
 						value : dataPoint,
 						label : data.labels[index],
 						datasetLabel: dataset.label,
-						strokeColor : dataset.strokeColor,
-						fillColor : dataset.fillColor,
-						highlightFill : dataset.highlightFill || dataset.fillColor,
-						highlightStroke : dataset.highlightStroke || dataset.strokeColor
+						strokeColor : dataset.strokeColor.constructor === Array ? dataset.strokeColor[index] : dataset.strokeColor,
+						fillColor : dataset.fillColor.constructor === Array ? dataset.fillColor[index] : dataset.fillColor,
+						highlightFill : highlightFill.constructor === Array ? highlightFill[index] : highlightFill,
+						highlightStroke : highlightStroke.constructor === Array ? highlightStroke[index] : highlightStroke
 					}));
 				},this);
 

--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ For support using Chart.js, please post questions with the [`chartjs` tag on Sta
 ## License
 
 Chart.js is available under the [MIT license](http://opensource.org/licenses/MIT).
+
+About this fork
+-------
+- Support for multi colored bar charts


### PR DESCRIPTION
This change adds the ability to define fillColor, strokeColor, highlightFill, and highlightStroke options as either a string or an array inside the dataset definition. The multicolored charts look great if you're only graphing a single dataset. 

Ugly example:

    var data = {
        labels: ["January", "February", "March"],
        datasets: [
            {
                label: "My First dataset",
                fillColor: ["rgba(220,220,220,0.5)",  "rgba(0,100,220,0.5)",  "rgba(220,0,220,0.5)"],
                strokeColor: ["rgba(220,220,220,0.8)", "rgba(220,120,220,0.8)", "rgba(220,80,220,0.8)"],
                highlightFill: ["rgba(13,220,220,0.75)", "rgba(220,220,200,0.75)", "rgba(220,50,220,0.75)"],
                highlightStroke: ["rgba(220,220,220,1)", "rgba(220,220,220,0.6)", "rgba(220,220,220, 0.2)"],
                data: [65, 59, 80]
            }
        ]
    };