### PR TITLE
Improve the rendering of negative values in the bar chart.

### DIFF
--- a/samples/bar.html
+++ b/samples/bar.html
@@ -11,7 +11,7 @@
 
 
 	<script>
-	var randomScalingFactor = function(){ return Math.round(Math.random()*100)};
+	var randomScalingFactor = function(){ return (Math.random() > 0.5 ? 1.0 : -1.0) * Math.round(Math.random()*100)};
 
 	var barChartData = {
 		labels : ["January","February","March","April","May","June","July"],
@@ -36,7 +36,8 @@
 	window.onload = function(){
 		var ctx = document.getElementById("canvas").getContext("2d");
 		window.myBar = new Chart(ctx).Bar(barChartData, {
-			responsive : true
+			responsive : true,
+			scaleBeginAtZero: false,
 		});
 	}
 

--- a/src/Chart.Bar.js
+++ b/src/Chart.Bar.js
@@ -149,6 +149,7 @@
 			if (this.scale.beginAtZero || ((this.scale.min <= 0 && this.scale.max >= 0) || (this.scale.min >= 0 && this.scale.max <= 0)))
 			{
 				base = this.scale.calculateY(0);
+				base += this.options.scaleGridLineWidth;
 			}
 			else if (this.scale.min < 0 && this.scale.max < 0)
 			{

--- a/src/Chart.Bar.js
+++ b/src/Chart.Bar.js
@@ -146,7 +146,7 @@
 		calculateBarBase: function() {
 			var base = this.scale.endPoint;
 			
-			if (this.scale.beginAtZero || ((this.scale.min < 0 && this.scale.max > 0) || (this.scale.min > 0 && this.scale.max < 0)))
+			if (this.scale.beginAtZero || ((this.scale.min <= 0 && this.scale.max >= 0) || (this.scale.min >= 0 && this.scale.max <= 0)))
 			{
 				base = this.scale.calculateY(0);
 			}

--- a/src/Chart.Bar.js
+++ b/src/Chart.Bar.js
@@ -146,11 +146,11 @@
 		calculateBarBase: function() {
 			var base = this.scale.endPoint;
 			
-			if (this.scale.beginAtZero || Math.sign(this.scale.min) != Math.sign(this.scale.max))
+			if (this.scale.beginAtZero || ((this.scale.min < 0 && this.scale.max > 0) || (this.scale.min > 0 && this.scale.max < 0)))
 			{
 				base = this.scale.calculateY(0);
 			}
-			else if (Math.sign(this.scale.min) < 0 && Math.sign(this.scale.max) < 0)
+			else if (this.scale.min < 0 && this.scale.max < 0)
 			{
 				// All values are negative. Use the top as the base
 				base = this.scale.startPoint;

--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -1279,7 +1279,14 @@
 			return this.base - this.y;
 		},
 		inRange : function(chartX,chartY){
-			return (chartX >= this.x - this.width/2 && chartX <= this.x + this.width/2) && (chartY >= this.y && chartY <= this.base);
+			if (this.y < this.base)
+			{
+				return (chartX >= this.x - this.width/2 && chartX <= this.x + this.width/2) && (chartY >= this.y && chartY <= this.base);
+			}
+			else
+			{
+				return (chartX >= this.x - this.width / 2 && chartX <= this.x + this.width / 2) && (chartY >= this.base && chartY <= this.y);
+			}
 		}
 	});
 


### PR DESCRIPTION
Inspired by #669, this is a fix for #9. Changed the bar chart drawing so that negative bars are drawn downwards. The animations are changed so that bars flow outward from the base towards the final value in all cases. If the scale has a `0` point, the animations flow from here. I updated the sample file to include both positive and negative values.

When both positive and negative values exist, the chart draws as such:
![Negative and positive bar chart](http://i.imgur.com/n7NVkg5.png)

When only positive values exist, the chart draws like this:
![Positive chart](http://i.imgur.com/u6O7dgI.png)

When only negative values exist, the chart draws like this:
![Negative chart](http://i.imgur.com/SCaRvfy.png)