### PR TITLE
Allow shadows on stroke

### DIFF
--- a/src/Chart.Line.js
+++ b/src/Chart.Line.js
@@ -95,6 +95,10 @@
 					label : dataset.label || null,
 					fillColor : dataset.fillColor,
 					strokeColor : dataset.strokeColor,
+					strokeShadowOffsetX: dataset.strokeShadowOffsetX || 0,
+					strokeShadowOffsetY: dataset.strokeShadowOffsetY || 0,
+					strokeShadowBlur: dataset.strokeShadowBlur || 0,
+					strokeShadowColor: dataset.strokeShadowColor || 'rgba(0, 0, 0, 0)',
 					pointColor : dataset.pointColor,
 					pointStrokeColor : dataset.pointStrokeColor,
 					points : []
@@ -275,6 +279,10 @@
 			helpers.each(this.datasets,function(dataset){
 				var pointsWithValues = helpers.where(dataset.points, hasValue);
 
+				ctx.shadowOffsetX = dataset.strokeShadowOffsetX;
+				ctx.shadowOffsetY = dataset.strokeShadowOffsetY;
+				ctx.shadowBlur = dataset.strokeShadowBlur;
+				ctx.shadowColor = dataset.strokeShadowColor;
 				//Transition each point first so that the line and point drawing isn't out of sync
 				//We can use this extra loop to calculate the control points of this dataset also in this loop
 
@@ -286,6 +294,7 @@
 						}, easingDecimal);
 					}
 				},this);
+
 
 
 				// Control points need to be calculated in a seperate loop, because we need to know the current x/y of the point


### PR DESCRIPTION
Allows for stroke to have a shadow, and a per dataset bases, by setting the canvas stroke properties. I'm not sure if I covered all the bases here, please let me know if I'm missing something.