### PR TITLE
Properly size unattached canvas

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -37,8 +37,8 @@
 			}
 		}
 
-		var width = this.width = computeDimension(context.canvas,'Width');
-		var height = this.height = computeDimension(context.canvas,'Height');
+		var width = this.width = computeDimension(context.canvas,'Width') || context.canvas.width;
+		var height = this.height = computeDimension(context.canvas,'Height') || context.canvas.height;
 
 		// Firefox requires this to work correctly
 		context.canvas.width  = width;


### PR DESCRIPTION
Fixes #990, fall back to `context.canvas.width` & `context.canvas.height` if dimensions cannot be intelligently procured