### PR TITLE
fix custom build bug

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,11 +24,11 @@ var srcDir = './src/';
 gulp.task('build', function(){
 
 	// Default to all of the chart types, with Chart.Core first
-	var srcFiles = [new FileName('Core')],
+	var srcFiles = [FileName('Core')],
 		isCustom = !!(util.env.types),
 		outputDir = (isCustom) ? 'custom' : '.';
 	if (isCustom){
-		util.env.types.split(',').forEach(function(type){ return srcFiles.push(new FileName(type));});
+		util.env.types.split(',').forEach(function(type){ return srcFiles.push(FileName(type));});
 	}
 	else{
 		// Seems gulp-concat remove duplicates - nice!


### PR DESCRIPTION
I followed the instructions on 06-Advanced.md, after I typed:

 gulp build --types=Bar

an error occurred, as shown below:

$ gulp build --types=Bar
[15:50:54] Using gulpfile f:\learning_chartjs\gulpfile.js
[15:50:54] Starting 'build'...
[15:50:54] 'build' errored after 952 μs
[15:50:54] Error: Invalid glob argument: [object Object],[object Object]
    at Gulp.src (f:\learning_chartjs\node_modules\gulp\node_modules\vinyl-fs\lib
\src\index.js:20:11)
    at Gulp.gulp.task.inquirer.prompt.type (f:\learning_chartjs\gulpfile.js:39:1
4)
    at module.exports (f:\learning_chartjs\node_modules\gulp\node_modules\orches
trator\lib\runTask.js:34:7)
    at Gulp.Orchestrator._runTask (f:\learning_chartjs\node_modules\gulp\node_mo
dules\orchestrator\index.js:273:3)
    at Gulp.Orchestrator._runStep (f:\learning_chartjs\node_modules\gulp\node_mo
dules\orchestrator\index.js:214:10)
    at Gulp.Orchestrator.start (f:\learning_chartjs\node_modules\gulp\node_modul
es\orchestrator\index.js:134:8)
    at d:\Users\zhuyimin\AppData\Roaming\npm\node_modules\gulp\bin\gulp.js:129:2
0
    at process._tickCallback (node.js:415:13)
    at Function.Module.runMain (module.js:499:11)
    at startup (node.js:119:16)


and I found that the arguments of gulp.src() should be an string or an array of strings, but not an array of Objects. so I just removed the new operator.