### PR TITLE
x-labels filter option

### DIFF
--- a/docs/01-Line-Chart.md
+++ b/docs/01-Line-Chart.md
@@ -57,9 +57,9 @@ These are the customisation options specific to Line charts. These options are m
 ```javascript
 {
 
-	//Function - Whether the current x-axis label should be filtered out, takes in current label and 
-	//index, returns true to filter out the label returns false to keep the label
-	labelsFilter : function(label,index){return false},
+	//Function - Whether the current x-axis label should be filtered out, takes in current label,  
+	//index and full label array, returns true to filter out the label returns false to keep the label
+	labelsFilter : function(label, index, labels){return false},
 	
 	///Boolean - Whether grid lines are shown across the chart
 	scaleShowGridLines : true,
@@ -116,7 +116,7 @@ For example, we could have a line chart without bezier curves between points by 
 ```javascript
 new Chart(ctx).Line(data, {
 	bezierCurve: false,
-	labelsFilter: function(value, index)
+	labelsFilter: function(value, index, labels)
 	{	
 		return (index+1)%5 !== 0;
 	}

--- a/docs/01-Line-Chart.md
+++ b/docs/01-Line-Chart.md
@@ -57,6 +57,10 @@ These are the customisation options specific to Line charts. These options are m
 ```javascript
 {
 
+	//Function - Whether the current x-axis label should be filtered out, takes in current label and 
+	//index, returns true to filter out the label returns false to keep the label
+	labelsFilter : function(label,index){return false},
+	
 	///Boolean - Whether grid lines are shown across the chart
 	scaleShowGridLines : true,
 
@@ -111,10 +115,15 @@ For example, we could have a line chart without bezier curves between points by 
 
 ```javascript
 new Chart(ctx).Line(data, {
-	bezierCurve: false
+	bezierCurve: false,
+	labelsFilter: function(value, index)
+	{	
+		return (index+1)%5 !== 0;
+	}
 });
 // This will create a chart with all of the default options, merged from the global config,
 // and the Line chart defaults, but this particular instance will have `bezierCurve` set to false.
+// It will also only display every 5th x-axis label
 ```
 
 We can also change these defaults values for each Line type that is created, this object is available at `Chart.defaults.Line`.

--- a/docs/02-Bar-Chart.md
+++ b/docs/02-Bar-Chart.md
@@ -53,9 +53,9 @@ These are the customisation options specific to Bar charts. These options are me
 
 ```javascript
 {
-	//Function - Whether the current x-axis label should be filtered out, takes in current label and 
-	//index, returns true to filter out the label returns false to keep the label
-	labelsFilter : function(label,index){return false},
+	//Function - Whether the current x-axis label should be filtered out, takes in current label,  
+	//index and full label array, returns true to filter out the label returns false to keep the label
+	labelsFilter : function(label, index, labels){return false},
 	
 	//Boolean - Whether the scale should start at zero, or an order of magnitude down from the lowest value
 	scaleBeginAtZero : true,
@@ -100,7 +100,7 @@ For example, we could have a bar chart without a stroke on each bar by doing the
 ```javascript
 new Chart(ctx).Bar(data, {
 	barShowStroke: false,
-	labelsFilter: function(value, index)
+	labelsFilter: function(value, index, labels)
 	{	
 		return (index+1)%5 !== 0;
 	}

--- a/docs/02-Bar-Chart.md
+++ b/docs/02-Bar-Chart.md
@@ -53,6 +53,10 @@ These are the customisation options specific to Bar charts. These options are me
 
 ```javascript
 {
+	//Function - Whether the current x-axis label should be filtered out, takes in current label and 
+	//index, returns true to filter out the label returns false to keep the label
+	labelsFilter : function(label,index){return false},
+	
 	//Boolean - Whether the scale should start at zero, or an order of magnitude down from the lowest value
 	scaleBeginAtZero : true,
 
@@ -95,10 +99,15 @@ For example, we could have a bar chart without a stroke on each bar by doing the
 
 ```javascript
 new Chart(ctx).Bar(data, {
-	barShowStroke: false
+	barShowStroke: false,
+	labelsFilter: function(value, index)
+	{	
+		return (index+1)%5 !== 0;
+	}
 });
 // This will create a chart with all of the default options, merged from the global config,
 //  and the Bar chart defaults but this particular instance will have `barShowStroke` set to false.
+// It will also only display every 5th x-axis label
 ```
 
 We can also change these defaults values for each Bar type that is created, this object is available at `Chart.defaults.Bar`.

--- a/samples/bar.html
+++ b/samples/bar.html
@@ -36,7 +36,11 @@
 	window.onload = function(){
 		var ctx = document.getElementById("canvas").getContext("2d");
 		window.myBar = new Chart(ctx).Bar(barChartData, {
-			responsive : true
+			responsive : true,
+			labelsFilter: function(value, index)
+			{	
+				return (index+1)%2 !== 0;
+			}
 		});
 	}
 

--- a/samples/bar.html
+++ b/samples/bar.html
@@ -37,8 +37,9 @@
 		var ctx = document.getElementById("canvas").getContext("2d");
 		window.myBar = new Chart(ctx).Bar(barChartData, {
 			responsive : true,
-			labelsFilter: function(value, index)
+			labelsFilter: function(value, index, labels)
 			{	
+				console.log(labels)
 				return (index+1)%2 !== 0;
 			}
 		});

--- a/samples/bar.html
+++ b/samples/bar.html
@@ -39,7 +39,6 @@
 			responsive : true,
 			labelsFilter: function(value, index, labels)
 			{	
-				console.log(labels)
 				return (index+1)%2 !== 0;
 			}
 		});

--- a/samples/line.html
+++ b/samples/line.html
@@ -44,7 +44,11 @@
 	window.onload = function(){
 		var ctx = document.getElementById("canvas").getContext("2d");
 		window.myLine = new Chart(ctx).Line(lineChartData, {
-			responsive: true
+			responsive: true,
+			labelsFilter: function(value, index)
+			{	
+				return (index+1)%2 !== 0;
+			}
 		});
 	}
 

--- a/samples/line.html
+++ b/samples/line.html
@@ -45,7 +45,7 @@
 		var ctx = document.getElementById("canvas").getContext("2d");
 		window.myLine = new Chart(ctx).Line(lineChartData, {
 			responsive: true,
-			labelsFilter: function(value, index)
+			labelsFilter: function(value, index, labels)
 			{	
 				return (index+1)%2 !== 0;
 			}

--- a/src/Chart.Bar.js
+++ b/src/Chart.Bar.js
@@ -7,9 +7,9 @@
 
 
 	var defaultConfig = {
-		//Function - Whether the current x-axis label should be filtered out, takes in current label and 
-		//index, returns true to filter out the label returns false to keep the label
-		labelsFilter : function(label,index){return false},
+		//Function - Whether the current x-axis label should be filtered out, takes in current label,  
+		//index and full label array, returns true to filter out the label returns false to keep the label
+		labelsFilter : function(label, index, labels){return false},
 		//Boolean - Whether the scale should start at zero, or an order of magnitude down from the lowest value
 		scaleBeginAtZero : true,
 

--- a/src/Chart.Bar.js
+++ b/src/Chart.Bar.js
@@ -7,6 +7,9 @@
 
 
 	var defaultConfig = {
+		//Function - Whether the current x-axis label should be filtered out, takes in current label and 
+		//index, returns true to filter out the label returns false to keep the label
+		labelsFilter : function(label,index){return false},
 		//Boolean - Whether the scale should start at zero, or an order of magnitude down from the lowest value
 		scaleBeginAtZero : true,
 
@@ -187,6 +190,7 @@
 			};
 
 			var scaleOptions = {
+				labelsFilter: this.options.labelsFilter,
 				templateString : this.options.scaleLabel,
 				height : this.chart.height,
 				width : this.chart.width,

--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -1727,6 +1727,11 @@
 				},this);
 
 				each(this.xLabels,function(label,index){
+
+					//if filter returns true do not draw this label
+					if (this.labelsFilter(label, index)){
+						return;
+					}
 					var xPos = this.calculateX(index) + aliasPixel(this.lineWidth),
 						// Check to see if line/bar here and decide where to place the line
 						linePos = this.calculateX(index - (this.offsetGridLines ? 0.5 : 0)) + aliasPixel(this.lineWidth),

--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -1729,7 +1729,7 @@
 				each(this.xLabels,function(label,index){
 
 					//if filter returns true do not draw this label
-					if (this.labelsFilter(label, index)){
+					if (this.labelsFilter(label, index, this.xLabels)){
 						return;
 					}
 					var xPos = this.calculateX(index) + aliasPixel(this.lineWidth),

--- a/src/Chart.Line.js
+++ b/src/Chart.Line.js
@@ -7,9 +7,9 @@
 
 	var defaultConfig = {
 
-		//Function - Whether the current x-axis label should be filtered out, takes in current label and 
-		//index, returns true to filter out the label returns false to keep the label
-		labelsFilter : function(label,index){return false},
+		//Function - Whether the current x-axis label should be filtered out, takes in current label,  
+		//index and full label array, returns true to filter out the label returns false to keep the label
+		labelsFilter : function(label, index, labels){return false},
 
 		///Boolean - Whether grid lines are shown across the chart
 		scaleShowGridLines : true,

--- a/src/Chart.Line.js
+++ b/src/Chart.Line.js
@@ -7,6 +7,10 @@
 
 	var defaultConfig = {
 
+		//Function - Whether the current x-axis label should be filtered out, takes in current label and 
+		//index, returns true to filter out the label returns false to keep the label
+		labelsFilter : function(label,index){return false},
+
 		///Boolean - Whether grid lines are shown across the chart
 		scaleShowGridLines : true,
 
@@ -171,6 +175,7 @@
 			};
 
 			var scaleOptions = {
+				labelsFilter: this.options.labelsFilter,
 				templateString : this.options.scaleLabel,
 				height : this.chart.height,
 				width : this.chart.width,


### PR DESCRIPTION
With a few options for this type of feature begin around at the moment i though i would add in my way of achieving it. It's basically a function that returns true if the label is to be filtered out (and not show) or false if it is to not be filtered out (shown). The reason i went for this method is it gives more control over the final output.

The function is given the value of the label, the index and the full label array so that all of these can be considered when deciding to filter the label. 

a few examples

filter out by index every other label
- http://jsfiddle.net/leighking2/9770Lwtc/

show first and last label
- http://jsfiddle.net/leighking2/uz8ot1mq/

show first last and x number of labels to create a spread (crap explanation but when you see it you should understand what i mean)
- http://jsfiddle.net/leighking2/7nn2s9kt/

show only labels that contain a 2 in them
- http://jsfiddle.net/leighking2/mpkv1zbz/



I also did not touch the rotation of the labels because i found that when they are rotated it is clear which point the label is attached to, where as when you ignore the now missing labels and don't rotate, the label will span several points and it can be unclear which one it is attached to.
