### PR TITLE
Setting test infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,5 @@ node_js:
   - "0.11"
   - "0.10"
 
-before_script:
-  - npm install
-
-script:
-  - gulp test
-
 notifications:
   slack: chartjs:pcfCZR6ugg5TEcaLtmIfQYuA

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,6 +15,8 @@ var gulp = require('gulp'),
 	bower = require('./bower.json');
 
 var srcDir = './src/';
+var testDir = './test/spec/';
+
 /*
  *	Usage : gulp build --types=Bar,Line,Doughnut
  *	Output: - A built Chart.js file with Core and types Bar, Line and Doughnut concatenated together
@@ -86,7 +88,7 @@ gulp.task('release', ['build'], function(){
 });
 
 gulp.task('jshint', function(){
-	return gulp.src(srcDir + '*.js')
+	return gulp.src([srcDir + '*.js', testDir + '*.js'])
 		.pipe(jshint())
 		.pipe(jshint.reporter('default'));
 });
@@ -116,8 +118,6 @@ gulp.task('watch', function(){
 	gulp.watch('./src/*', ['build']);
 });
 
-gulp.task('test', ['jshint', 'valid']);
-
 gulp.task('size', ['library-size', 'module-sizes']);
 
 gulp.task('default', ['build', 'watch']);
@@ -135,3 +135,10 @@ gulp.task('_open', function(){
 });
 
 gulp.task('dev', ['server', 'default']);
+
+var mochaPhantomJS = require('gulp-mocha-phantomjs');
+gulp.task('test', ['jshint', 'valid'], function(){
+  return gulp
+  .src('test/runner.html')
+  .pipe(mochaPhantomJS());
+});

--- a/package.json
+++ b/package.json
@@ -13,14 +13,18 @@
     "gulp": "3.5.x",
     "gulp-concat": "~2.1.x",
     "gulp-connect": "~2.0.5",
+    "gulp-html-validator": "^0.0.2",
     "gulp-jshint": "~1.5.1",
+    "gulp-mocha-phantomjs": "^0.5.3",
     "gulp-replace": "^0.4.0",
     "gulp-size": "~0.4.0",
     "gulp-uglify": "~0.2.x",
     "gulp-util": "~2.2.x",
-    "gulp-html-validator": "^0.0.2",
     "inquirer": "^0.5.1",
-    "semver": "^3.0.1"
+    "semver": "^3.0.1",
+    "mocha": "~1.14.0",
+    "chai": "~1.8.0",
+    "sinon": "^1.12.2"
   },
   "spm": {
     "main": "Chart.js"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "url": "https://github.com/nnnick/Chart.js.git"
   },
+  "scripts": {
+    "test": "gulp test"
+  },
   "dependences": {},
   "devDependencies": {
     "gulp": "3.5.x",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--reporter spec
+--ui bdd
+--recursive

--- a/test/runner.html
+++ b/test/runner.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Mocha Spec Runner</title>
+    <link rel="stylesheet" href="../node_modules/mocha/mocha.css">
+</head>
+<body>
+    <div id="mocha"></div>
+
+    <script src="../node_modules/mocha/mocha.js"></script>
+    <script>mocha.setup('bdd');</script>
+    <script src="../node_modules/chai/chai.js"></script>
+    <script src="../node_modules/sinon/pkg/sinon.js"></script>
+    <script> var expect = chai.expect;</script>
+
+    <!-- include source files here... -->
+    <script src="../Chart.js"></script>
+
+    <!-- include spec files here... -->
+    <script src="spec/bar_spec.js"></script>
+
+    <script>
+      if (window.mochaPhantomJS) {
+        mochaPhantomJS.run();
+      } else {
+        mocha.run();
+      }
+    </script>
+</body>
+</html>

--- a/test/spec/bar_spec.js
+++ b/test/spec/bar_spec.js
@@ -1,6 +1,7 @@
 /* global describe, it */
 (function () {
   describe('Bar Chart Function Test', function () {
+    this.timeout(5000);
     beforeEach(function() {
       this.canvasElement = document.createElement('canvas');
       this.canvasElement.id = 'canvas';
@@ -11,6 +12,17 @@
 
     afterEach(function() {
       document.body.removeChild(this.canvasElement);
+    });
+
+    it('test width', function(done) {
+      var canvas = document.getElementById("canvas")
+      expect(canvas.width).to.equal(500);
+      var ctx = document.getElementById("canvas").getContext("2d");
+      var moveToSpy = sinon.spy(ctx, 'moveTo');
+      ctx.moveTo(10,20);
+      expect(moveToSpy.calledWith(10, 20)).to.equal(true);
+
+      done();
     });
 
     it('should run here few assertions', function(done) {

--- a/test/spec/bar_spec.js
+++ b/test/spec/bar_spec.js
@@ -1,0 +1,98 @@
+/* global describe, it */
+(function () {
+  describe('Bar Chart Function Test', function () {
+    beforeEach(function() {
+      this.canvasElement = document.createElement('canvas');
+      this.canvasElement.id = 'canvas';
+      this.canvasElement.width =  500;
+      this.canvasElement.height = 500;
+      document.body.appendChild(this.canvasElement);
+    });
+
+    afterEach(function() {
+      document.body.removeChild(this.canvasElement);
+    });
+
+    it('should run here few assertions', function(done) {
+      var ctx = document.getElementById("canvas").getContext("2d");
+
+      var moveToSpy = sinon.spy(ctx, 'moveTo');
+      var lineToSpy = sinon.spy(ctx, 'lineTo');
+
+      var expectedValues = [
+        { base: 477, leftX: 29.5,  rightX: 134.5, top: 323, },
+        { base: 477, leftX: 137.5, rightX: 242.5, top: 168, },
+        { base: 477, leftX: 254.5, rightX: 359.5, top: 168, },
+        { base: 477, leftX: 362.5, rightX: 467.5, top: 13, },
+      ];
+
+      /*
+      // NOTE: This is the way to get the expectedValues
+
+      var datasetsLength = myBar.datasets.length;
+      for(var i = 0; i < datasetsLength; i++) {
+        var bars = myBar.datasets[i].bars;
+
+        for(var j = 0; j < bars.length; j++) {
+          var width = myBar.scale.calculateBarWidth(bars.length);
+          var x =     myBar.scale.calculateBarX(datasetsLength, j, i);
+          var y =     myBar.scale.calculateY(bars[j].value);
+          var base =  myBar.scale.endPoint;
+
+          var halfWidth = width / 2;
+
+          var expectation = {
+            base:      base,
+            leftX:     x - halfWidth,
+            rightX:    x + halfWidth,
+            top:       base - (base - y),
+          };
+
+          if(myBar.options.barShowStroke) {
+            var halfStroke = myBar.options.barStrokeWidth / 2;
+            expectation.leftX  += halfStroke;
+            expectation.rightX -= halfStroke;
+            expectation.top    += halfStroke;
+          }
+
+          expectedValues.push(expectation);
+        }
+      }
+       */
+
+      var options = {
+        onAnimationComplete: function() {
+          expectedValues.forEach(function(expected) {
+            expect(moveToSpy.calledWith(expected.leftX,  expected.base)).to.equal(true);
+            expect(lineToSpy.calledWith(expected.leftX,   expected.top)).to.equal(true);
+            expect(lineToSpy.calledWith(expected.rightX,  expected.top)).to.equal(true);
+            expect(lineToSpy.calledWith(expected.rightX, expected.base)).to.equal(true);
+          });
+          done();
+        },
+      };
+
+      var barChartData = {
+        labels : ["January","February"],
+        datasets : [
+          {
+            fillColor : "rgba(220,220,220,0.5)",
+            strokeColor : "rgba(220,220,220,0.8)",
+            highlightFill: "rgba(220,220,220,0.75)",
+            highlightStroke: "rgba(220,220,220,1)",
+            data: [10, 20],
+          },
+          {
+            fillColor : "rgba(151,187,205,0.5)",
+            strokeColor : "rgba(151,187,205,0.8)",
+            highlightFill : "rgba(151,187,205,0.75)",
+            highlightStroke : "rgba(151,187,205,1)",
+            data: [20, 30],
+          }
+        ]
+      };
+
+      var myBar = new Chart(ctx).Bar(barChartData, options);
+    });
+  });
+})();


### PR DESCRIPTION
The intention of this PR is to show a working example for a posible test infrastructure for Chart.js.
The idea is to use a combination of `mocha`, `chai` and `sinon` and run them from `gulp` with `gulp-mocha-phantomjs`.

Please let me know what you think.

In order to run this:
```
gulp test
```
Install dependencies before:
```
npm install
```