### PR TITLE
FIx for tooltips being cut of canvas

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -1347,6 +1347,7 @@
 		}
 	});
 
+
 	Chart.Tooltip = Chart.Element.extend({
 		draw : function(){
 
@@ -1357,78 +1358,111 @@
 			this.xAlign = "center";
 			this.yAlign = "above";
 
-			//Distance between the actual element.y position and the start of the tooltip caret
-			var caretPadding = this.caretPadding = 2;
+	        	//Distance between the actual element.y position and the start of the tooltip caret
+	        	var caretPadding = this.caretPadding = 2;
 
 			var tooltipWidth = ctx.measureText(this.text).width + 2*this.xPadding,
 				tooltipRectHeight = this.fontSize + 2*this.yPadding,
 				tooltipHeight = tooltipRectHeight + this.caretHeight + caretPadding;
-
+				
 			if (this.x + tooltipWidth/2 >this.chart.width){
 				this.xAlign = "left";
 			} else if (this.x - tooltipWidth/2 < 0){
 				this.xAlign = "right";
 			}
-
+			
 			if (this.y - tooltipHeight < 0){
 				this.yAlign = "below";
 			}
 
 
-			var tooltipX = this.x - tooltipWidth/2,
-				tooltipY = this.y - tooltipHeight;
-
-			ctx.fillStyle = this.fillColor;
-
-			// Custom Tooltips
-			if(this.custom){
-				this.custom(this);
-			}
-			else{
-				switch(this.yAlign)
-				{
-				case "above":
-					//Draw a caret above the x/y
-					ctx.beginPath();
-					ctx.moveTo(this.x,this.y - caretPadding);
-					ctx.lineTo(this.x + this.caretHeight, this.y - (caretPadding + this.caretHeight));
-					ctx.lineTo(this.x - this.caretHeight, this.y - (caretPadding + this.caretHeight));
-					ctx.closePath();
-					ctx.fill();
-					break;
-				case "below":
-					tooltipY = this.y + caretPadding + this.caretHeight;
-					//Draw a caret below the x/y
-					ctx.beginPath();
-					ctx.moveTo(this.x, this.y + caretPadding);
-					ctx.lineTo(this.x + this.caretHeight, this.y + caretPadding + this.caretHeight);
-					ctx.lineTo(this.x - this.caretHeight, this.y + caretPadding + this.caretHeight);
-					ctx.closePath();
-					ctx.fill();
-					break;
-				}
-
-				switch(this.xAlign)
-				{
-				case "left":
-					tooltipX = this.x - tooltipWidth + (this.cornerRadius + this.caretHeight);
-					break;
-				case "right":
-					tooltipX = this.x - (this.cornerRadius + this.caretHeight);
-					break;
-				}
-
-				drawRoundedRectangle(ctx,tooltipX,tooltipY,tooltipWidth,tooltipRectHeight,this.cornerRadius);
-
-				ctx.fill();
-
-				ctx.fillStyle = this.textColor;
-				ctx.textAlign = "center";
-				ctx.textBaseline = "middle";
-				ctx.fillText(this.text, tooltipX + tooltipWidth/2, tooltipY + tooltipRectHeight/2);
-			}
-		}
-	});
+		        var tooltipX = this.x - tooltipWidth / 2,
+		        		tooltipY = this.y - tooltipHeight;
+	
+	
+		        if (this.x > ctx.canvas.width - tooltipWidth / 2) {
+		            this.xAlign = "offsetLeft";
+		            this.yAlign = "right";
+		        } else if (this.x < (tooltipWidth / 2)) {
+		            this.xAlign = "offsetRight";
+		            this.yAlign = "left";
+		        }
+	
+		        ctx.fillStyle = this.fillColor;
+	
+		        // Custom Tooltips
+		        if (this.custom) {
+		            this.custom(this);
+		        }
+		        else {
+		            switch (this.yAlign) {
+		                case "above":
+		                    //Draw a caret above the x/y
+		                    ctx.beginPath();
+		                    ctx.moveTo(this.x, this.y - caretPadding);
+		                    ctx.lineTo(this.x + this.caretHeight, this.y - (caretPadding + this.caretHeight));
+		                    ctx.lineTo(this.x - this.caretHeight, this.y - (caretPadding + this.caretHeight));
+		                    ctx.closePath();
+		                    ctx.fill();
+		                    break;
+		                case "below":
+		                    tooltipY = this.y + caretPadding + this.caretHeight;
+		                    //Draw a caret below the x/y
+		                    ctx.beginPath();
+		                    ctx.moveTo(this.x, this.y + caretPadding);
+		                    ctx.lineTo(this.x + this.caretHeight, this.y + caretPadding + this.caretHeight);
+		                    ctx.lineTo(this.x - this.caretHeight, this.y + caretPadding + this.caretHeight);
+		                    ctx.closePath();
+		                    ctx.fill();
+		                    break;
+		                case "right":
+		                    tooltipY = this.y - (caretPadding * 2) - this.caretHeight
+		                    //Draw a caret to the right of the x/y with a slight reduction of size
+		                    ctx.beginPath();
+		                    ctx.moveTo(this.x, this.y + caretPadding);
+		                    ctx.lineTo(this.x - this.caretHeight, this.y + caretPadding + 5);  // the factor of 5 reduces the size of the caret for asthestics 
+		                    ctx.lineTo(this.x - this.caretHeight, this.y - 5);
+		                    ctx.closePath();
+		                    ctx.fill();
+		                    break
+		                case "left":
+		                    tooltipY = this.y - (caretPadding * 2) - this.caretHeight
+		                    //Draw a caret to the left of the x/y with a slight reduction of size
+		                    ctx.beginPath();
+		                    ctx.moveTo(this.x, this.y + caretPadding);
+		                    ctx.lineTo(this.x + this.caretHeight, this.y + caretPadding + 5);
+		                    ctx.lineTo(this.x + this.caretHeight, this.y - 5);
+		                    ctx.closePath();
+		                    ctx.fill();
+		                    break;
+	
+		            }
+	
+		            switch (this.xAlign) {
+		                case "left":
+		                    tooltipX = this.x - tooltipWidth + (this.cornerRadius + this.caretHeight);
+		                    break;
+		                case "right":
+		                    tooltipX = this.x - (this.cornerRadius + this.caretHeight);
+		                    break;
+		                case "offsetLeft":
+		                    tooltipX = this.x - tooltipWidth - this.cornerRadius - this.caretPadding;
+		                    break;
+		                case "offsetRight":
+		                    tooltipX = this.x + this.cornerRadius + this.caretPadding;
+		                    break;
+		            }
+	
+		            drawRoundedRectangle(ctx, tooltipX, tooltipY, tooltipWidth, tooltipRectHeight, this.cornerRadius);
+	
+		            ctx.fill();
+		            ctx.fillStyle = this.textColor;
+		            ctx.textAlign = "center";
+		            ctx.textBaseline = "middle";
+		            ctx.fillText(this.text, tooltipX + tooltipWidth / 2, tooltipY + tooltipRectHeight / 2);
+		        }
+		    }
+		});
 
 	Chart.MultiTooltip = Chart.Element.extend({
 		initialize : function(){


### PR DESCRIPTION
Workaround to for Bug #622. 

In order to prevent the tool tips from being cut off screen, I've implemented extra tool tip alignments for  when the tool tip would normally get cut off by the canvas. 

The fix is demonstrated here.  

![example](https://cloud.githubusercontent.com/assets/2990407/7157651/709a900e-e369-11e4-9eb1-3f5eb062e736.png)
 