### PR TITLE
Added a scaleBackgroundColors configuration option for radar charts, to...

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -2004,31 +2004,39 @@
 					ctx.lineWidth = this.angleLineWidth;
 					ctx.strokeStyle = this.angleLineColor;
 					for (var i = this.valuesCount - 1; i >= 0; i--) {
+						var centerOffset = null, outerPosition = null;
+
 						if (this.angleLineWidth > 0){
-							var centerOffset = this.calculateCenterOffset(this.max);
-							var outerPosition = this.getPointPosition(i, centerOffset);
+							centerOffset = this.calculateCenterOffset(this.max);
+							outerPosition = this.getPointPosition(i, centerOffset);
 							ctx.beginPath();
 							ctx.moveTo(this.xCenter, this.yCenter);
 							ctx.lineTo(outerPosition.x, outerPosition.y);
 							ctx.stroke();
 							ctx.closePath();
+						}
 
-							if (this.backgroundColors && this.backgroundColors.length == this.valuesCount) {
-								var previousOuterPosition = this.getPointPosition(i === 0 ? this.valuesCount - 1 : i - 1, centerOffset);
-								var nextOuterPosition = this.getPointPosition(i === this.valuesCount - 1 ? 0 : i + 1, centerOffset);
+						if (this.backgroundColors && this.backgroundColors.length == this.valuesCount) {
+							if (centerOffset == null)
+								centerOffset = this.calculateCenterOffset(this.max);
 
-								var previousOuterHalfway = { x: (previousOuterPosition.x + outerPosition.x) / 2, y: (previousOuterPosition.y + outerPosition.y) / 2 };
-								var nextOuterHalfway = { x: (outerPosition.x + nextOuterPosition.x) / 2, y: (outerPosition.y + nextOuterPosition.y) / 2 };
+							if (outerPosition == null)
+								outerPosition = this.getPointPosition(i, centerOffset);
 
-								ctx.beginPath();
-								ctx.moveTo(this.xCenter, this.yCenter);
-								ctx.lineTo(previousOuterHalfway.x, previousOuterHalfway.y);
-								ctx.lineTo(outerPosition.x, outerPosition.y);
-								ctx.lineTo(nextOuterHalfway.x, nextOuterHalfway.y);
-								ctx.fillStyle = this.backgroundColors[i];
-								ctx.fill();
-								ctx.closePath();
-							}
+							var previousOuterPosition = this.getPointPosition(i === 0 ? this.valuesCount - 1 : i - 1, centerOffset);
+							var nextOuterPosition = this.getPointPosition(i === this.valuesCount - 1 ? 0 : i + 1, centerOffset);
+
+							var previousOuterHalfway = { x: (previousOuterPosition.x + outerPosition.x) / 2, y: (previousOuterPosition.y + outerPosition.y) / 2 };
+							var nextOuterHalfway = { x: (outerPosition.x + nextOuterPosition.x) / 2, y: (outerPosition.y + nextOuterPosition.y) / 2 };
+
+							ctx.beginPath();
+							ctx.moveTo(this.xCenter, this.yCenter);
+							ctx.lineTo(previousOuterHalfway.x, previousOuterHalfway.y);
+							ctx.lineTo(outerPosition.x, outerPosition.y);
+							ctx.lineTo(nextOuterHalfway.x, nextOuterHalfway.y);
+							ctx.fillStyle = this.backgroundColors[i];
+							ctx.fill();
+							ctx.closePath();
 						}
 						// Extra 3px out for some label spacing
 						var pointLabelPosition = this.getPointPosition(i, this.calculateCenterOffset(this.max) + 5);

--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -2005,16 +2005,17 @@
 					ctx.strokeStyle = this.angleLineColor;
 					for (var i = this.valuesCount - 1; i >= 0; i--) {
 						if (this.angleLineWidth > 0){
-							var outerPosition = this.getPointPosition(i, this.calculateCenterOffset(this.max));
+							var centerOffset = this.calculateCenterOffset(this.max);
+							var outerPosition = this.getPointPosition(i, centerOffset);
 							ctx.beginPath();
 							ctx.moveTo(this.xCenter, this.yCenter);
 							ctx.lineTo(outerPosition.x, outerPosition.y);
 							ctx.stroke();
 							ctx.closePath();
 
-							if (this.backgroundColors) {
-								var previousOuterPosition = this.getPointPosition(i === 0 ? this.valuesCount - 1 : i - 1, this.calculateCenterOffset(this.max));
-								var nextOuterPosition = this.getPointPosition(i === this.valuesCount - 1 ? 0 : i + 1, this.calculateCenterOffset(this.max));
+							if (this.backgroundColors && this.backgroundColors.length == this.valuesCount) {
+								var previousOuterPosition = this.getPointPosition(i === 0 ? this.valuesCount - 1 : i - 1, centerOffset);
+								var nextOuterPosition = this.getPointPosition(i === this.valuesCount - 1 ? 0 : i + 1, centerOffset);
 
 								var previousOuterHalfway = { x: (previousOuterPosition.x + outerPosition.x) / 2, y: (previousOuterPosition.y + outerPosition.y) / 2 };
 								var nextOuterHalfway = { x: (outerPosition.x + nextOuterPosition.x) / 2, y: (outerPosition.y + nextOuterPosition.y) / 2 };

--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -2011,6 +2011,23 @@
 							ctx.lineTo(outerPosition.x, outerPosition.y);
 							ctx.stroke();
 							ctx.closePath();
+
+							if (this.backgroundColors) {
+								var previousOuterPosition = this.getPointPosition(i === 0 ? this.valuesCount - 1 : i - 1, this.calculateCenterOffset(this.max));
+								var nextOuterPosition = this.getPointPosition(i === this.valuesCount - 1 ? 0 : i + 1, this.calculateCenterOffset(this.max));
+
+								var previousOuterHalfway = { x: (previousOuterPosition.x + outerPosition.x) / 2, y: (previousOuterPosition.y + outerPosition.y) / 2 };
+								var nextOuterHalfway = { x: (outerPosition.x + nextOuterPosition.x) / 2, y: (outerPosition.y + nextOuterPosition.y) / 2 };
+
+								ctx.beginPath();
+								ctx.moveTo(this.xCenter, this.yCenter);
+								ctx.lineTo(previousOuterHalfway.x, previousOuterHalfway.y);
+								ctx.lineTo(outerPosition.x, outerPosition.y);
+								ctx.lineTo(nextOuterHalfway.x, nextOuterHalfway.y);
+								ctx.fillStyle = this.backgroundColors[i];
+								ctx.fill();
+								ctx.closePath();
+							}
 						}
 						// Extra 3px out for some label spacing
 						var pointLabelPosition = this.getPointPosition(i, this.calculateCenterOffset(this.max) + 5);

--- a/src/Chart.Radar.js
+++ b/src/Chart.Radar.js
@@ -174,6 +174,7 @@
 				showLabels: this.options.scaleShowLabels,
 				showLabelBackdrop: this.options.scaleShowLabelBackdrop,
 				backdropColor: this.options.scaleBackdropColor,
+				backgroundColors: this.options.scaleBackgroundColors,
 				backdropPaddingY : this.options.scaleBackdropPaddingY,
 				backdropPaddingX: this.options.scaleBackdropPaddingX,
 				lineWidth: (this.options.scaleShowLine) ? this.options.scaleLineWidth : 0,


### PR DESCRIPTION
... add a background color for each axis in the chart.

I had this particular requirement to color code the axes of the radar chart to match a color coded table - was using Highcharts before but it was super easy to add it into Chart.js (looks better too!).  Don't know how useful it would be for general use.

![radarbgcolor](https://cloud.githubusercontent.com/assets/128848/7185898/b1182086-e41a-11e4-9151-c22d111cbf83.PNG)
