### PR TITLE
Prevent taking vertical space for X labels more than once

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -1554,6 +1554,9 @@
 			this.startPoint += this.padding;
 			this.endPoint -= this.padding;
 
+			// Cache the starting endpoint, excluding the space for x labels
+			var cachedEndPoint = this.endPoint;
+
 			// Cache the starting height, so can determine if we need to recalculate the scale yAxis
 			var cachedHeight = this.endPoint - this.startPoint,
 				cachedYLabelWidth;
@@ -1585,6 +1588,7 @@
 
 				// Only go through the xLabel loop again if the yLabel width has changed
 				if (cachedYLabelWidth < this.yLabelWidth){
+					this.endPoint = cachedEndPoint;
 					this.calculateXLabelRotation();
 				}
 			}


### PR DESCRIPTION
The `fit` method runs some calculations in a loop in order to generate a Y axis that fits between the start point and the end point. Inside that loop it might call `calculateXLabelRotation()` which subtracts space needed for X labels from the endPoint. However, if this method is called more than once, then the space
is subtracted more than once, and the chart gets smaller and smaller with every iteration. The result is that I had one graph rendering like this, with extra space at the bottom, because the space for the X labels was taken twice:

![screen shot 2015-04-16 at 22 30 06](https://cloud.githubusercontent.com/assets/28465/7190702/3e140cee-e488-11e4-8c99-ae7d199ec93a.png)

This fix makes sure that the endPoint is reset before calling `calculateXLabelRotation`, so the space for X labels is always subtracted from the initial value as it was before starting the loop.
