### PR TITLE
Stop animations when destroying a chart

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -952,6 +952,7 @@
 			return template(this.options.legendTemplate,this);
 		},
 		destroy : function(){
+			this.stop();
 			this.clear();
 			unbindEvents(this, this.events);
 			var canvas = this.chart.canvas;


### PR DESCRIPTION
This adds a call to `stop()` in `destroy()` to make sure a scheduled animation which runs `draw()` in a loop is also stopped when the chart is cleaned up. Otherwise, the animation keeps updating the chart for some time after it was supposed to be destroyed, even though the canvas might have been already reused for a new chart.

In my case, I have some buttons which switch between different chart types when pressed, and if you pressed them too fast, the canvas wouldn't be updated properly, because the old chart was still rendering in the animation thread while the new one was being created.
