### PR TITLE
updated ignore section of bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,5 +7,13 @@
   "main": [
     "Chart.js"
   ],
+  "ignore": [
+    "*",
+    "!src/*",
+    "!Chart.js",
+    "!Chart.min.js",
+    "!LICENSE.md",
+    "!README.md"
+  ],
   "dependencies": {}
 }


### PR DESCRIPTION
Bower is typically used to install front end dependencies. This update is to reflect standard practice of only including src and dist (plus license and readme) for bower installs.

This also fixes a warning when installing using bower:

> bower Chart.js#~1.0.2     invalid-meta Chart.js is missing "ignore" entry in bower.json