### PR TITLE
transitions on charts that start with no values calculate based on NaN and cannot take live updates

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -1203,8 +1203,12 @@
 			return this;
 		},
 		transition : function(props,ease){
-			each(props,function(value,key){
-				this[key] = ((value - this._saved[key]) * ease) + this._saved[key];
+		    	each(props,function(value,key){
+			    	if (!isNaN(_saved[key])) {
+				    	this[key] = ((value - this._saved[key]) * ease) + this._saved[key];
+				} else {
+				    	this[key] = value;
+				}
 			},this);
 			return this;
 		},


### PR DESCRIPTION

Initial calculations on, for example, a Pie or Doughnut chart rely on the chart having an initial 'total' to
calculate circumference et. al.  When this value is initially zero (a chart with no data) then the segments
cannot transition out of this state due to the "ease" calculation.  This patch applies the value directly and
skips easing when the existing segment value is NaN.