### PR TITLE
When the dataset scale is not displaying, set the padding correctly.

### DIFF
--- a/src/Chart.Scale.js
+++ b/src/Chart.Scale.js
@@ -687,8 +687,8 @@
                 }
             } else {
                 this.labelWidth = 0;
-                this.paddingRight = this.padding;
-                this.paddingLeft = this.padding;
+                this.paddingRight = 0;
+                this.paddingLeft = 0;
             }
 
         },


### PR DESCRIPTION
If this is not done, the x value for each point is NaN and as a result, the graph does not draw.