### PR TITLE
Scale fit updates

### DIFF
--- a/src/Chart.Scale.js
+++ b/src/Chart.Scale.js
@@ -406,7 +406,7 @@
                 //		-----------------------------------------------------
                 //			|			|			|			|			|
                 //
-                minSize.height = this.options.gridLines.show ? 25 : 0;
+                minSize.height = this.options.gridLines.show ? 10 : 0;
             } else {
                 minSize.height = maxHeight; // fill all the height
 
@@ -422,7 +422,7 @@
                 //	    |
                 //		|
                 //	   -|
-                minSize.width = this.options.gridLines.show ? 25 : 0;
+                minSize.width = this.options.gridLines.show ? 10 : 0;
             }
 
             if (this.options.labels.show) {
@@ -473,8 +473,8 @@
                         hasZero = helpers.findNextWhere(this.ticks, function(tick) {
                             return tick === 0;
                         }) !== undefined;
-                        var yTickStart = this.options.position == "bottom" ? this.top : this.bottom - 10;
-                        var yTickEnd = this.options.position == "bottom" ? this.top + 10 : this.bottom;
+                        var yTickStart = this.options.position == "bottom" ? this.top : this.bottom - 5;
+                        var yTickEnd = this.options.position == "bottom" ? this.top + 5 : this.bottom;
 
                         helpers.each(this.ticks, function(tick, index) {
                             // Grid lines are vertical
@@ -542,8 +542,8 @@
                         hasZero = helpers.findNextWhere(this.ticks, function(tick) {
                             return tick === 0;
                         }) !== undefined;
-                        var xTickStart = this.options.position == "right" ? this.left : this.right - 10;
-                        var xTickEnd = this.options.position == "right" ? this.left + 10 : this.right;
+                        var xTickStart = this.options.position == "right" ? this.left : this.right - 5;
+                        var xTickEnd = this.options.position == "right" ? this.left + 5 : this.right;
 
                         helpers.each(this.ticks, function(tick, index) {
                             // Grid lines are horizontal
@@ -584,22 +584,22 @@
                         // Draw the labels
 
                         var labelStartX;
-                        var maxLabelWidth = this.width - 25;
-
+                        
                         if (this.options.position == "left") {
-                            labelStartX = this.left;
+                            labelStartX = this.right - 10;
+                            this.ctx.textAlign = "right";
                         } else {
                             // right side
-                            labelStartX = this.left + 20;
+                            labelStartX = this.left + 5;
+                            this.ctx.textAlign = "left"
                         }
 
-                        this.ctx.textAlign = "left";
                         this.ctx.textBaseline = "middle";
                         this.ctx.font = helpers.fontString(this.options.labels.fontSize, this.options.labels.fontStyle, this.options.labels.fontFamily);
 
                         helpers.each(this.labels, function(label, index) {
                             var yValue = this.getPixelForValue(this.ticks[index]);
-                            this.ctx.fillText(label, labelStartX, yValue, maxLabelWidth);
+                            this.ctx.fillText(label, labelStartX, yValue);
                         }, this);
                     }
                 }

--- a/src/Chart.Scale.js
+++ b/src/Chart.Scale.js
@@ -11,8 +11,8 @@
     Chart.scaleService = {
         // The interesting function
         fitScalesForChart: function(chartInstance, width, height) {
-            var xPadding = 10;
-            var yPadding = 10;
+            var xPadding = 5;
+            var yPadding = 5;
 
             if (chartInstance) {
                 var leftScales = helpers.where(chartInstance.scales, function(scaleInstance) {
@@ -518,14 +518,15 @@
                         var labelStartY;
 
                         if (this.options.position == "top") {
-                            labelStartY = this.top;
+                            labelStartY = this.bottom - 10;
+                            this.ctx.textBaseline = "bottom";
                         } else {
                             // bottom side
-                            labelStartY = this.top + 20;
+                            labelStartY = this.top + 10;
+                            this.ctx.textBaseline = "top";
                         }
 
                         this.ctx.textAlign = "center";
-                        this.ctx.textBaseline = "top";
                         this.ctx.font = helpers.fontString(this.options.labels.fontSize, this.options.labels.fontStyle, this.options.labels.fontFamily);
 
                         helpers.each(this.labels, function(label, index) {
@@ -584,7 +585,7 @@
                         // Draw the labels
 
                         var labelStartX;
-                        
+
                         if (this.options.position == "left") {
                             labelStartX = this.right - 10;
                             this.ctx.textAlign = "right";


### PR DESCRIPTION
## Overview
This update to the scale fitting algorithm improves the rendering of dataset axes. The fitting algorithm was changed from 2 passes to 2.5 passes. This allows the `fit` function of each scale to be passed an object containing the margins around the scale. The margin is the unused area that can be used if necessary. For a horizontal dataset axis, this is the area underneath the vertical axes on the left and right sides of the chart. When rendering labels, especially rotated labels, this area is used to prevent unnecessary padding of the left side of the chart.

## Old display
![line chart old](https://cloud.githubusercontent.com/assets/6757853/8019796/dfee2fb8-0c2e-11e5-9c17-be721d86434b.png)

## New Display
![line chart new](https://cloud.githubusercontent.com/assets/6757853/8019797/e53072ec-0c2e-11e5-8c7b-804aadc4e918.png)

