### PR TITLE
Improvements to angle calculations in polar area charts

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -1442,8 +1442,8 @@
             });
 
             // Put into the range of (-PI/2, 3PI/2]
-            var startAngle = vm.startAngle < (-0.5 * Math.PI) ? vm.startAngle + (2.0 * Math.PI) : vm.startAngle;
-            var endAngle = vm.endAngle < (-0.5 * Math.PI) ? vm.endAngle + (2.0 * Math.PI) : vm.endAngle
+            var startAngle = vm.startAngle < (-0.5 * Math.PI) ? vm.startAngle + (2.0 * Math.PI) : vm.startAngle > (1.5 * Math.PI) ? vm.startAngle - (2.0 * Math.PI): vm.startAngle;
+            var endAngle = vm.endAngle < (-0.5 * Math.PI) ? vm.endAngle + (2.0 * Math.PI) : vm.endAngle > (1.5 * Math.PI) ? vm.endAngle - (2.0 * Math.PI) : vm.endAngle
 
             //Check if within the range of the open/close angle
             var betweenAngles = (pointRelativePosition.angle >= startAngle && pointRelativePosition.angle <= endAngle),

--- a/src/Chart.PolarArea.js
+++ b/src/Chart.PolarArea.js
@@ -148,9 +148,6 @@
 
                 var value = this.data.datasets[0].data[index];
 
-                var startAngle = Math.PI * 1.5 + (Math.PI * circumference) * index;
-                var endAngle = startAngle + (circumference * Math.PI);
-
                 helpers.extend(slice, {
                     _index: index,
                     _model: {
@@ -158,8 +155,8 @@
                         y: this.chart.height / 2,
                         innerRadius: 0,
                         outerRadius: 0,
-                        startAngle: Math.PI * 1.5,
-                        endAngle: Math.PI * 1.5,
+                        startAngle: Math.PI * -0.5,
+                        endAngle: Math.PI * -0.5,
 
                         backgroundColor: slice.custom && slice.custom.backgroundColor ? slice.custom.backgroundColor : helpers.getValueAtIndexOrDefault(this.data.datasets[0].backgroundColor, index, this.options.elements.slice.backgroundColor),
                         hoverBackgroundColor: slice.custom && slice.custom.hoverBackgroundColor ? slice.custom.hoverBackgroundColor : helpers.getValueAtIndexOrDefault(this.data.datasets[0].hoverBackgroundColor, index, this.options.elements.slice.hoverBackgroundColor),
@@ -189,7 +186,7 @@
 
                 var value = this.data.datasets[0].data[index];
 
-                var startAngle = Math.PI * 1.5 + (Math.PI * circumference) * index;
+                var startAngle = (-0.5 * Math.PI) + (Math.PI * circumference) * index;
                 var endAngle = startAngle + (circumference * Math.PI);
 
                 helpers.extend(slice, {


### PR DESCRIPTION
Ensures that angles from polar area charts are similar to those in doughnut / pie charts. Fixes an issue that prevented tooltips from displaying on polar area charts in `v2.0.0-alpha`