### PR TITLE
By default use toLocaleString() when generating labels for the axes. …

### DIFF
--- a/src/Chart.Line.js
+++ b/src/Chart.Line.js
@@ -66,7 +66,7 @@
                 // label settings
                 labels: {
                     show: true,
-                    template: "<%=value%>",
+                    template: "<%=value.toLocaleString()%>",
                     fontSize: 12,
                     fontStyle: "normal",
                     fontColor: "#666",

--- a/src/Chart.PolarArea.js
+++ b/src/Chart.PolarArea.js
@@ -30,7 +30,7 @@
             // label settings
             labels: {
                 show: true,
-                template: "<%=value%>",
+                template: "<%=value.toLocaleString()%>",
                 fontSize: 12,
                 fontStyle: "normal",
                 fontColor: "#666",

--- a/src/Chart.Radar.js
+++ b/src/Chart.Radar.js
@@ -39,7 +39,7 @@
                 // label settings
                 labels: {
                     show: true,
-                    template: "<%=value%>",
+                    template: "<%=value.toLocaleString()%>",
                     fontSize: 12,
                     fontStyle: "normal",
                     fontColor: "#666",

--- a/src/Chart.Scatter.js
+++ b/src/Chart.Scatter.js
@@ -36,7 +36,7 @@
                 // label settings
                 labels: {
                     show: true,
-                    template: "<%=value%>",
+                    template: "<%=value.toLocaleString()%>",
                     fontSize: 12,
                     fontStyle: "normal",
                     fontColor: "#666",
@@ -68,7 +68,7 @@
                 // label settings
                 labels: {
                     show: true,
-                    template: "<%=value%>",
+                    template: "<%=value.toLocaleString()%>",
                     fontSize: 12,
                     fontStyle: "normal",
                     fontColor: "#666",


### PR DESCRIPTION
This prevents poorly formatted numbers due to doubles. It also makes large numbers nicer with commas by default.

## Old behaviour
![old small number display](https://cloud.githubusercontent.com/assets/6757853/8097099/a55d5528-0fac-11e5-9a1f-b8139f639f86.png)


## New behaviour
![new small number display](https://cloud.githubusercontent.com/assets/6757853/8097091/90f02976-0fac-11e5-8753-16581c3ddd0e.png)

![big numbers](https://cloud.githubusercontent.com/assets/6757853/8097095/9a6081cc-0fac-11e5-9828-9a65e68cd8b0.png)
