### PR TITLE
Create interfaces similar to the old interfaces. 

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,7 @@ gulp.task('build', function() {
             './src/controllers/**',
             './src/scales/**',
             './src/elements/**',
-            './src/charts/chart.bar.js',
+            './src/charts/**',
             './node_modules/color/dist/color.min.js'
         ],
         isCustom = !!(util.env.types),

--- a/samples/bar-multi-axis.html
+++ b/samples/bar-multi-axis.html
@@ -45,8 +45,7 @@
     };
     window.onload = function() {
         var ctx = document.getElementById("canvas").getContext("2d");
-        window.myBar = new Chart(ctx, {
-            type: 'bar',
+        window.myBar = Chart.Bar(ctx, {
             data: barChartData, 
             options: {
                 responsive: true,

--- a/samples/line-multi-axis.html
+++ b/samples/line-multi-axis.html
@@ -45,7 +45,7 @@
 
     window.onload = function() {
         var ctx = document.getElementById("canvas").getContext("2d");
-        window.myLine = new Chart(ctx).Line({
+        window.myLine = Chart.Line(ctx, {
             data: lineChartData,
             options: {
                 responsive: true,

--- a/samples/polar-area.html
+++ b/samples/polar-area.html
@@ -21,7 +21,6 @@
     };
 
     var config = {
-        type: 'polarArea',
         data: {
             datasets: [{
                 data: [
@@ -54,7 +53,7 @@
 
     window.onload = function() {
         var ctx = document.getElementById("chart-area");
-        window.myPolarArea = new Chart(ctx, config);
+        window.myPolarArea = Chart.PolarArea(ctx, config);
     };
 
     $('#randomizeData').click(function() {

--- a/samples/scatter-multi-axis.html
+++ b/samples/scatter-multi-axis.html
@@ -90,7 +90,7 @@
 
     window.onload = function() {
         var ctx = document.getElementById("canvas").getContext("2d");
-        window.myScatter = new Chart(ctx).Scatter({
+        window.myScatter = Chart.Scatter(ctx, {
         	data: scatterChartData,
         	options: {
 	            responsive: true,

--- a/samples/scatter.html
+++ b/samples/scatter.html
@@ -86,15 +86,14 @@
 
     window.onload = function() {
         var ctx = document.getElementById("canvas").getContext("2d");
-        window.myScatter = new Chart(ctx).Scatter({
+        window.myScatter = Chart.Scatter(ctx, {
         	data: scatterChartData,
         	options: {
-	            responsive: true,
-	            hoverMode: 'single', // should always use single for a scatter chart
 	            scales: {
 	            	xAxes: [{
+	            		position: 'top',
 	            		gridLines: {
-	            			zeroLineColor: "rgba(0,0,0,1)"
+	            			zeroLineColor: "rgba(0,255,0,1)"
 	            		}
 	            	}]
 	            }

--- a/src/charts/Chart.Bar.js
+++ b/src/charts/Chart.Bar.js
@@ -1,0 +1,14 @@
+(function() {
+	"use strict";
+
+	var root = this;
+	var Chart = root.Chart;
+	var helpers = Chart.helpers;
+
+	Chart.Bar = function(context, config) {
+		config.type = 'bar';
+
+		return new Chart(context, config);
+	}
+	
+}).call(this);

--- a/src/charts/Chart.Doughnut.js
+++ b/src/charts/Chart.Doughnut.js
@@ -1,0 +1,14 @@
+(function() {
+	"use strict";
+
+	var root = this;
+	var Chart = root.Chart;
+	var helpers = Chart.helpers;
+
+	Chart.Doughnut = function(context, config) {
+		config.type = 'doughnut';
+
+		return new Chart(context, config);
+	}
+	
+}).call(this);

--- a/src/charts/Chart.Line.js
+++ b/src/charts/Chart.Line.js
@@ -1,0 +1,14 @@
+(function() {
+	"use strict";
+
+	var root = this;
+	var Chart = root.Chart;
+	var helpers = Chart.helpers;
+
+	Chart.Line = function(context, config) {
+		config.type = 'line';
+
+		return new Chart(context, config);
+	}
+	
+}).call(this);

--- a/src/charts/Chart.PolarArea.js
+++ b/src/charts/Chart.PolarArea.js
@@ -1,0 +1,14 @@
+(function() {
+	"use strict";
+
+	var root = this;
+	var Chart = root.Chart;
+	var helpers = Chart.helpers;
+
+	Chart.PolarArea = function(context, config) {
+		config.type = 'polarArea';
+
+		return new Chart(context, config);
+	}
+	
+}).call(this);

--- a/src/charts/Chart.Radar.js
+++ b/src/charts/Chart.Radar.js
@@ -1,0 +1,14 @@
+(function() {
+	"use strict";
+
+	var root = this;
+	var Chart = root.Chart;
+	var helpers = Chart.helpers;
+
+	Chart.Radar = function(context, config) {
+		config.type = 'radar';
+
+		return new Chart(context, config);
+	}
+	
+}).call(this);

--- a/src/charts/Chart.Scatter.js
+++ b/src/charts/Chart.Scatter.js
@@ -1,11 +1,9 @@
 (function() {
 	"use strict";
 
-	return;
-
-	var root = this,
-		Chart = root.Chart,
-		helpers = Chart.helpers;
+	var root = this;
+	var Chart = root.Chart;
+	var helpers = Chart.helpers;
 
 	var defaultConfig = {
 		hover: {
@@ -35,9 +33,10 @@
 
 	};
 
-
-	Chart.types.Line.extend({
-		name: "Scatter",
-		defaults: defaultConfig,
-	});
+	Chart.Scatter = function(context, config) {
+		config.options = helpers.configMerge(defaultConfig, config.options);
+		config.type = 'line';
+		return new Chart(context, config);
+	}
+	
 }).call(this);

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -14,9 +14,11 @@
 		scales: {
 			xAxes: [{
 				type: "category",
+				id: 'x-axis-0'
 			}],
 			yAxes: [{
 				type: "linear",
+				id: 'y-axis-0'
 			}],
 		},
 	};

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -51,6 +51,7 @@
 
 			// Make sure controllers are built first so that each dataset is bound to an axis before the scales
 			// are built
+			this.ensureScalesHaveIDs();
 			this.buildControllers();
 			this.buildScales();
 			this.resetElements();
@@ -91,7 +92,25 @@
 
 			return this;
 		},
+		ensureScalesHaveIDs: function ensureScalesHaveIDs() {
+			var defaultXAxisID = 'x-axis-';
+			var defaultYAxisID = 'y-axis-';
 
+			if (this.options.scales) {
+				if (this.options.scales.xAxes && this.options.scales.xAxes.length) {
+					helpers.each(this.options.scales.xAxes, function(xAxisOptions, index) {
+						xAxisOptions.id = xAxisOptions.id || (defaultXAxisID + index);
+					}, this);
+				}
+
+				if (this.options.scales.yAxes && this.options.scales.yAxes.length) {
+					// Build the y axes
+					helpers.each(this.options.scales.yAxes, function(yAxisOptions, index) {
+						yAxisOptions.id = yAxisOptions.id || (defaultYAxisID + index);
+					}, this);
+				}
+			}
+		},
 		buildScales: function buildScales() {
 			// Map of scale ID to scale object so we can lookup later 
 			this.scales = {};
@@ -99,7 +118,7 @@
 			// Build the x axes
 			if (this.options.scales) {
 				if (this.options.scales.xAxes && this.options.scales.xAxes.length) {
-					helpers.each(this.options.scales.xAxes, function(xAxisOptions) {
+					helpers.each(this.options.scales.xAxes, function(xAxisOptions, index) {
 						var ScaleClass = Chart.scaleService.getScaleConstructor(xAxisOptions.type);
 						var scale = new ScaleClass({
 							ctx: this.chart.ctx,
@@ -114,7 +133,7 @@
 
 				if (this.options.scales.yAxes && this.options.scales.yAxes.length) {
 					// Build the y axes
-					helpers.each(this.options.scales.yAxes, function(yAxisOptions) {
+					helpers.each(this.options.scales.yAxes, function(yAxisOptions, index) {
 						var ScaleClass = Chart.scaleService.getScaleConstructor(yAxisOptions.type);
 						var scale = new ScaleClass({
 							ctx: this.chart.ctx,

--- a/src/scales/scale.category.js
+++ b/src/scales/scale.category.js
@@ -9,7 +9,6 @@
 	var defaultConfig = {
 		display: true,
 		position: "bottom",
-		id: "x-axis-1", // need an ID so datasets can reference the scale
 
 		// grid line settings
 		gridLines: {

--- a/src/scales/scale.linear.js
+++ b/src/scales/scale.linear.js
@@ -8,7 +8,6 @@
 	var defaultConfig = {
 		display: true,
 		position: "left",
-		id: "y-axis-1",
 
 		// grid line settings
 		gridLines: {


### PR DESCRIPTION
Ensure that scales always have IDs before controllers are built.

The old interfaces have become:
`Chart.Line(context, config)`
`Chart.Bar(context, config)`
`Chart.Radar(context, config)`
`Chart.Scatter(context, config)`
`Chart.PolarArea(context, config)`
`Chart.Doughnut(context, config)`

It is not necessary to use `new` with these interfaces. You must use `new` if you are using the advanced interface. Example: `new Chart(ctx, config)`