### PR TITLE
New Feature: Add tooltipFontColor as an attribute on the data point for donut/pie chart

### DIFF
--- a/docs/05-Pie-Doughnut-Chart.md
+++ b/docs/05-Pie-Doughnut-Chart.md
@@ -51,7 +51,7 @@ var data = [
 		color: "#FDB45C",
 		highlight: "#FFC870",
 		label: "Yellow",
-        tooltipFontColor: "#FDB45C"
+		tooltipFontColor: "#FDB45C"
 	}
 ]
 ```

--- a/docs/05-Pie-Doughnut-Chart.md
+++ b/docs/05-Pie-Doughnut-Chart.md
@@ -50,7 +50,8 @@ var data = [
 		value: 100,
 		color: "#FDB45C",
 		highlight: "#FFC870",
-		label: "Yellow"
+		label: "Yellow",
+        tooltipFontColor: "#FDB45C"
 	}
 ]
 ```

--- a/docs/05-Pie-Doughnut-Chart.md
+++ b/docs/05-Pie-Doughnut-Chart.md
@@ -55,7 +55,7 @@ var data = [
 ]
 ```
 
-For a pie chart, you must pass in an array of objects with a value and an optional color property. The value attribute should be a number, Chart.js will total all of the numbers and calculate the relative proportion of each. The color attribute should be a string. Similar to CSS, for this string you can use HEX notation, RGB, RGBA or HSL.
+For a pie chart, you must pass in an array of objects with a value and optional color and tooltipFontColor properties. The value attribute should be a number, Chart.js will total all of the numbers and calculate the relative proportion of each. The color and fontTooltipColor attributes should be a string. Similar to CSS, for this string you can use HEX notation, RGB, RGBA or HSL.
 
 ### Chart options
 

--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -1112,7 +1112,7 @@
 							xPadding: this.options.tooltipXPadding,
 							yPadding: this.options.tooltipYPadding,
 							fillColor: this.options.tooltipFillColor,
-							textColor: this.options.tooltipFontColor,
+							textColor: Element.tooltipFontColor || this.options.tooltipFontColor,
 							fontFamily: this.options.tooltipFontFamily,
 							fontStyle: this.options.tooltipFontStyle,
 							fontSize: this.options.tooltipFontSize,

--- a/src/Chart.Doughnut.js
+++ b/src/Chart.Doughnut.js
@@ -103,7 +103,8 @@
 				strokeColor : this.options.segmentStrokeColor,
 				startAngle : Math.PI * 1.5,
 				circumference : (this.options.animateRotate) ? 0 : this.calculateCircumference(segment.value),
-				label : segment.label
+				label : segment.label,
+                tooltipFontColor : segment.tooltipFontColor
 			}));
 			if (!silent){
 				this.reflow();

--- a/src/Chart.Doughnut.js
+++ b/src/Chart.Doughnut.js
@@ -104,7 +104,7 @@
 				startAngle : Math.PI * 1.5,
 				circumference : (this.options.animateRotate) ? 0 : this.calculateCircumference(segment.value),
 				label : segment.label,
-                tooltipFontColor : segment.tooltipFontColor
+				tooltipFontColor : segment.tooltipFontColor
 			}));
 			if (!silent){
 				this.reflow();


### PR DESCRIPTION
I had a need for per-element tooltip font colors using the donut/pie chart.  The change is a new **tooltipFontColor** attribute that is customizable for each data point.  If it is not present, then the color will fallback to the normal options tooltipFontColor.  I only implemented this for regular Tooltip class and not the MultiTooltip class since donut/pie charts only have a single element.

An example data point would look like:
```
var data = [
	{
		value: 300,
		color:"#F7464A",
		highlight: "#FF5A5E",
		label: "Red",
		tooltipFontColor: "#FF5A5E"
	}
]
```

![screen shot 2015-06-23 at 10 08 27 pm](https://cloud.githubusercontent.com/assets/4042205/8323074/7ab97f98-19f4-11e5-9741-8b097393748c.png)

![screen shot 2015-06-23 at 10 08 49 pm](https://cloud.githubusercontent.com/assets/4042205/8323078/7f283d58-19f4-11e5-955d-7114cd558b08.png)
