### PR TITLE
add keywords to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,6 @@
   },
   "spm": {
     "main": "Chart.js"
-  }
+  },
+  "keywords": ["chart", "canvas", "line", "bar", "radar", "plot"]
 }


### PR DESCRIPTION
chart.js isn't really findable on npm. maybe this could help.