### PR TITLE
More robust in-between arc calculation see #1301

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -1281,9 +1281,18 @@
 				y: chartY
 			});
 
+			// Normalize all angles to 0 - 2*PI (0 - 360°)
+			var pointRelativeAngle = pointRelativePosition.angle % (Math.PI * 2),
+			var startAngle = (Math.PI * 2 + this.startAngle) % (Math.PI * 2),
+			var endAngle = (Math.PI * 2 + this.endAngle) % (Math.PI * 2) || 360;
+
+			// Calculate wether the pointRelativeAngle is between the start and the end angle
+			var betweenAngles = (endAngle < startAngle) ?
+				pointRelativeAngle <= endAngle || pointRelativeAngle >= startAngle:
+				pointRelativeAngle >= startAngle && pointRelativeAngle <= endAngle;
+
 			//Check if within the range of the open/close angle
-			var betweenAngles = (pointRelativePosition.angle >= this.startAngle && pointRelativePosition.angle <= this.endAngle),
-				withinRadius = (pointRelativePosition.distance >= this.innerRadius && pointRelativePosition.distance <= this.outerRadius);
+			var withinRadius = (pointRelativePosition.distance >= this.innerRadius && pointRelativePosition.distance <= this.outerRadius);
 
 			return (betweenAngles && withinRadius);
 			//Ensure within the outside of the arc centre, but inside arc outer

--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -1283,8 +1283,8 @@
 
 			// Normalize all angles to 0 - 2*PI (0 - 360°)
 			var pointRelativeAngle = pointRelativePosition.angle % (Math.PI * 2),
-			var startAngle = (Math.PI * 2 + this.startAngle) % (Math.PI * 2),
-			var endAngle = (Math.PI * 2 + this.endAngle) % (Math.PI * 2) || 360;
+			    startAngle = (Math.PI * 2 + this.startAngle) % (Math.PI * 2),
+			    endAngle = (Math.PI * 2 + this.endAngle) % (Math.PI * 2) || 360;
 
 			// Calculate wether the pointRelativeAngle is between the start and the end angle
 			var betweenAngles = (endAngle < startAngle) ?


### PR DESCRIPTION
In the [jsbin](https://jsbin.com/wohiyukaxe/edit?html,js,output) you will see that the current implementation is not able to measure that the current mouse position of (225°) is in range in the following arcs:

[0° - 360°]
[200° - 0°]
[90° - 230°]

See #1301