### PR TITLE
Allow separate bar hover event and tooltips

### DIFF
--- a/Chart.js
+++ b/Chart.js
@@ -174,6 +174,9 @@
 			// String - Colour behind the legend colour block
 			multiTooltipKeyBackground: '#fff',
 
+			//have separate hover event/tooltip for multiple datasets
+			separateHover: false,
+
 			// Function - Will fire on animation progression.
 			onAnimationProgress: function(){},
 
@@ -971,6 +974,12 @@
 							});
 
 							helpers.each(Elements, function(element) {
+								if (this.options.separateHover &&
+									typeof element.datasetLabel != "undefined" &&
+									element.datasetLabel != ChartElements[0].datasetLabel) {
+									return;
+								}
+
 								xPositions.push(element.x);
 								yPositions.push(element.y);
 
@@ -2189,8 +2198,13 @@
 			for (var datasetIndex = 0; datasetIndex < this.datasets.length; datasetIndex++) {
 				for (barIndex = 0; barIndex < this.datasets[datasetIndex].bars.length; barIndex++) {
 					if (this.datasets[datasetIndex].bars[barIndex].inRange(eventPosition.x,eventPosition.y)){
-						helpers.each(this.datasets, datasetIterator);
-						return barsArray;
+						if (this.options.separateHover) {
+							barsArray.push(this.datasets[datasetIndex].bars[barIndex]);
+							return barsArray;
+						} else {
+							helpers.each(this.datasets, datasetIterator);
+							return barsArray;
+						}
 					}
 				}
 			}

--- a/Chart.js
+++ b/Chart.js
@@ -174,12 +174,6 @@
 			// String - Colour behind the legend colour block
 			multiTooltipKeyBackground: '#fff',
 
-			//have separate hover event for multiple datasets
-			separateHover: false,
-
-			//when separate hover event, the ability to have all data in tooltip still or not
-			seperateHoverDistinctTooltip: true,
-
 			// Function - Will fire on animation progression.
 			onAnimationProgress: function(){},
 
@@ -977,13 +971,6 @@
 							});
 
 							helpers.each(Elements, function(element) {
-								if (this.options.separateHover &&
-									this.options.seperateHoverDistinctTooltip &&
-									typeof element.datasetLabel != "undefined" &&
-									element.datasetLabel != ChartElements[0].datasetLabel) {
-									return;
-								}
-
 								xPositions.push(element.x);
 								yPositions.push(element.y);
 
@@ -2202,13 +2189,8 @@
 			for (var datasetIndex = 0; datasetIndex < this.datasets.length; datasetIndex++) {
 				for (barIndex = 0; barIndex < this.datasets[datasetIndex].bars.length; barIndex++) {
 					if (this.datasets[datasetIndex].bars[barIndex].inRange(eventPosition.x,eventPosition.y)){
-						if (this.options.separateHover) {
-							barsArray.push(this.datasets[datasetIndex].bars[barIndex]);
-							return barsArray;
-						} else {
-							helpers.each(this.datasets, datasetIterator);
-							return barsArray;
-						}
+						helpers.each(this.datasets, datasetIterator);
+						return barsArray;
 					}
 				}
 			}

--- a/Chart.js
+++ b/Chart.js
@@ -174,8 +174,11 @@
 			// String - Colour behind the legend colour block
 			multiTooltipKeyBackground: '#fff',
 
-			//have separate hover event/tooltip for multiple datasets
+			//have separate hover event for multiple datasets
 			separateHover: false,
+
+			//when separate hover event, the ability to have all data in tooltip still or not
+			seperateHoverDistinctTooltip: true,
 
 			// Function - Will fire on animation progression.
 			onAnimationProgress: function(){},
@@ -975,6 +978,7 @@
 
 							helpers.each(Elements, function(element) {
 								if (this.options.separateHover &&
+									this.options.seperateHoverDistinctTooltip &&
 									typeof element.datasetLabel != "undefined" &&
 									element.datasetLabel != ChartElements[0].datasetLabel) {
 									return;

--- a/docs/00-Getting-Started.md
+++ b/docs/00-Getting-Started.md
@@ -198,6 +198,12 @@ Chart.defaults.global = {
 	// String - Template string for multiple tooltips
 	multiTooltipTemplate: "<%= value %>",
 
+	//have separate hover event for multiple datasets
+	separateHover: false,
+
+	//when separate hover event, the ability to have all data in tooltip still or not
+	seperateHoverDistinctTooltip: true,
+
 	// Function - Will fire on animation progression.
 	onAnimationProgress: function(){},
 

--- a/samples/bar-separateHoverEvents.html
+++ b/samples/bar-separateHoverEvents.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html>
+	<head>
+		<title>Bar Chart</title>
+		<script src="../Chart.js"></script>
+	</head>
+	<body>
+		<div style="width: 50%">
+			<canvas id="canvas" height="450" width="600"></canvas>
+		</div>
+
+
+	<script>
+	var randomScalingFactor = function(){ return Math.round(Math.random()*100)};
+
+	var barChartData = {
+		labels : ["January","February","March","April","May","June","July"],
+		datasets : [
+			{
+				fillColor : "rgba(220,220,220,0.5)",
+				strokeColor : "rgba(220,220,220,0.8)",
+				highlightFill: "rgba(220,220,220,0.75)",
+				highlightStroke: "rgba(220,220,220,1)",
+				data : [randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor()]
+			},
+			{
+				fillColor : "rgba(151,187,205,0.5)",
+				strokeColor : "rgba(151,187,205,0.8)",
+				highlightFill : "rgba(151,187,205,0.75)",
+				highlightStroke : "rgba(151,187,205,1)",
+				data : [randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor()]
+			}
+		]
+
+	}
+	window.onload = function(){
+		var ctx = document.getElementById("canvas").getContext("2d");
+		window.myBar = new Chart(ctx).Bar(barChartData, {
+			responsive : true
+		});
+	}
+
+	</script>
+	</body>
+</html>

--- a/samples/bar-separateHoverEvents.html
+++ b/samples/bar-separateHoverEvents.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 	<head>
-		<title>Bar Chart</title>
+		<title>Bar Multi-data, Separate Hover/Tooltip Chart</title>
 		<script src="../Chart.js"></script>
 	</head>
 	<body>
@@ -17,6 +17,7 @@
 		labels : ["January","February","March","April","May","June","July"],
 		datasets : [
 			{
+				label: "foo",
 				fillColor : "rgba(220,220,220,0.5)",
 				strokeColor : "rgba(220,220,220,0.8)",
 				highlightFill: "rgba(220,220,220,0.75)",
@@ -24,6 +25,7 @@
 				data : [randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor()]
 			},
 			{
+				label: "bar",
 				fillColor : "rgba(151,187,205,0.5)",
 				strokeColor : "rgba(151,187,205,0.8)",
 				highlightFill : "rgba(151,187,205,0.75)",
@@ -36,7 +38,8 @@
 	window.onload = function(){
 		var ctx = document.getElementById("canvas").getContext("2d");
 		window.myBar = new Chart(ctx).Bar(barChartData, {
-			responsive : true
+			responsive : true,
+			separateHover: true
 		});
 	}
 

--- a/samples/bar-separateHoverEvents.html
+++ b/samples/bar-separateHoverEvents.html
@@ -31,6 +31,14 @@
 				highlightFill : "rgba(151,187,205,0.75)",
 				highlightStroke : "rgba(151,187,205,1)",
 				data : [randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor()]
+			},
+			{
+				label: "baz",
+				fillColor : "rgba(240,0,0,0.5)",
+				strokeColor : "rgba(240,0,0,0.8)",
+				highlightFill : "rgba(240,0,0,0.75)",
+				highlightStroke : "rgba(240,0,0,1)",
+				data : [randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor()]
 			}
 		]
 

--- a/samples/bar-separateHoverEvents.html
+++ b/samples/bar-separateHoverEvents.html
@@ -47,7 +47,8 @@
 		var ctx = document.getElementById("canvas").getContext("2d");
 		window.myBar = new Chart(ctx).Bar(barChartData, {
 			responsive : true,
-			separateHover: true
+			separateHover: true,
+			//seperateHoverDistinctTooltip: false
 		});
 	}
 

--- a/samples/bar-separateHoverEvents.html
+++ b/samples/bar-separateHoverEvents.html
@@ -2,7 +2,8 @@
 <html>
 	<head>
 		<title>Bar Multi-data, Separate Hover/Tooltip Chart</title>
-		<script src="../Chart.js"></script>
+		<script src="../src/Chart.Core.js"></script>
+		<script src="../src/Chart.Bar.js"></script>
 	</head>
 	<body>
 		<div style="width: 50%">
@@ -48,7 +49,6 @@
 		window.myBar = new Chart(ctx).Bar(barChartData, {
 			responsive : true,
 			separateHover: true,
-			//seperateHoverDistinctTooltip: false
 		});
 	}
 

--- a/src/Chart.Bar.js
+++ b/src/Chart.Bar.js
@@ -167,6 +167,13 @@
 			for (var datasetIndex = 0; datasetIndex < this.datasets.length; datasetIndex++) {
 				for (barIndex = 0; barIndex < this.datasets[datasetIndex].bars.length; barIndex++) {
 					if (this.datasets[datasetIndex].bars[barIndex].inRange(eventPosition.x,eventPosition.y)){
+						if (this.options.separateHover) {
+							barsArray.push(this.datasets[datasetIndex].bars[barIndex]);
+							return barsArray;
+						} else {
+							helpers.each(this.datasets, datasetIterator);
+							return barsArray;
+						}
 						helpers.each(this.datasets, datasetIterator);
 						return barsArray;
 					}

--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -174,6 +174,12 @@
 			// String - Colour behind the legend colour block
 			multiTooltipKeyBackground: '#fff',
 
+			//have separate hover event for multiple datasets
+			separateHover: false,
+
+			//when separate hover event, the ability to have all data in tooltip still or not
+			seperateHoverDistinctTooltip: true,
+
 			// Function - Will fire on animation progression.
 			onAnimationProgress: function(){},
 
@@ -1053,6 +1059,14 @@
 							});
 
 							helpers.each(Elements, function(element) {
+								console.log(this.options);
+								if (this.options.separateHover &&
+									this.options.seperateHoverDistinctTooltip &&
+									typeof element.datasetLabel != "undefined" &&
+									element.datasetLabel != ChartElements[0].datasetLabel) {
+									return;
+								}
+
 								xPositions.push(element.x);
 								yPositions.push(element.y);
 

--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -1059,7 +1059,6 @@
 							});
 
 							helpers.each(Elements, function(element) {
-								console.log(this.options);
 								if (this.options.separateHover &&
 									this.options.seperateHoverDistinctTooltip &&
 									typeof element.datasetLabel != "undefined" &&


### PR DESCRIPTION
Adds the ability to have a single bar highlighted when using multiple datasets instead of all of a datagroup.

Also can display the normal multitooltiptemplate when a single bar is highlighted or just the current bar data.