### PR TITLE
Add support for mirror option on labels

### DIFF
--- a/docs/00-Getting-Started.md
+++ b/docs/00-Getting-Started.md
@@ -364,6 +364,12 @@ the following options.
     labels: {
         // Boolean - if true show labels
         show: true,
+        
+        // Boolean - if true the chart will mirror the axis labels. If the labels are on the left, mirroring the axis will render them to the right
+        mirror: false,
+        
+        // Number - controls the padding between the label and the axis
+        padding: 10,
 
         // String - template string for labels
         template: "<%=value%>",

--- a/src/scales/scale.linear.js
+++ b/src/scales/scale.linear.js
@@ -28,11 +28,13 @@
 		// label settings
 		labels: {
 			show: true,
+			mirror: false,
+			padding: 10,
 			template: "<%=value.toLocaleString()%>",
 			fontSize: 12,
 			fontStyle: "normal",
 			fontColor: "#666",
-			fontFamily: "Helvetica Neue",
+			fontFamily: "Helvetica Neue"
 		}
 	};
 
@@ -548,12 +550,22 @@
 						var labelStartX;
 
 						if (this.options.position == "left") {
-							labelStartX = this.right - 10;
-							this.ctx.textAlign = "right";
+							if (this.options.labels.mirror) {
+								labelStartX = this.right + this.options.labels.padding;
+								this.ctx.textAlign = "left";
+							} else {
+								labelStartX = this.right - this.options.labels.padding;
+								this.ctx.textAlign = "right";
+							}
 						} else {
 							// right side
-							labelStartX = this.left + 5;
-							this.ctx.textAlign = "left";
+							if (this.options.labels.mirror) {
+								labelStartX = this.left - this.options.labels.padding;
+								this.ctx.textAlign = "right";
+							} else {
+								labelStartX = this.left + this.options.labels.padding;
+								this.ctx.textAlign = "left";
+							}
 						}
 
 						this.ctx.textBaseline = "middle";


### PR DESCRIPTION
Hi,

This PR adds support for a mirror option (for now only for linear scale, I tried on category scale but it's a bit more tricky :(.

When set to true, the labels are rendered inside the chart instead of outside. This also adds support for a new "padding" option that allows to control how far the label is from the axis.

With mirror: false :

<img width="170" alt="capture d ecran 2015-08-05 a 17 39 56" src="https://cloud.githubusercontent.com/assets/1198915/9090242/70bb289a-3b99-11e5-8556-d8b8ad7fc4fe.png">

With mirror: true :

<img width="197" alt="capture d ecran 2015-08-05 a 17 40 05" src="https://cloud.githubusercontent.com/assets/1198915/9090251/79d37d38-3b99-11e5-981d-247119e04a71.png">
