### PR TITLE
The datasetStroke option has been fixed for line graphs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules/*
 custom/*
 
 docs/index.md
+
+.settings/

--- a/src/Chart.Line.js
+++ b/src/Chart.Line.js
@@ -355,7 +355,9 @@
 					}
 				}, this);
 
-				ctx.stroke();
+				if (this.options.datasetStroke) {
+					ctx.stroke();
+				}
 
 				if (this.options.datasetFill && pointsWithValues.length > 0){
 					//Round off the line by going to the base of the chart, back to the start, then fill.


### PR DESCRIPTION
Previously the datasetStroke option did nothing when set to false, but this update allows users to properly turn off the stroke on line graphs.