### PR TITLE
error thrown

### DIFF
--- a/src/Chart.Line.js
+++ b/src/Chart.Line.js
@@ -275,6 +275,7 @@
 				return helpers.findPreviousWhere(collection, hasValue, index) || point;
 			};
 
+			if (!this.scale) return;
 			this.scale.draw(easingDecimal);
 
 


### PR DESCRIPTION
error thrown (TypeError: this.scale is undefined) if destroy is called before animation is complete, this update fix this error!