### PR TITLE
Added tooltipTitleTemplate option.

### DIFF
--- a/docs/00-Getting-Started.md
+++ b/docs/00-Getting-Started.md
@@ -177,6 +177,9 @@ Chart.defaults.global = {
 	// String - Tooltip title font colour
 	tooltipTitleFontColor: "#fff",
 
+	// String - Tooltip title template
+	tooltipTitleTemplate: "<%= label%>",
+
 	// Number - pixel width of padding around tooltip text
 	tooltipYPadding: 6,
 

--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -150,6 +150,9 @@
 			// String - Tooltip title font colour
 			tooltipTitleFontColor: "#fff",
 
+			// String - Tooltip title template
+			tooltipTitleTemplate: "<%= label%>",
+
 			// Number - pixel width of padding around tooltip text
 			tooltipYPadding: 6,
 
@@ -1097,7 +1100,7 @@
 						labels: tooltipLabels,
 						legendColors: tooltipColors,
 						legendColorBackground : this.options.multiTooltipKeyBackground,
-						title: ChartElements[0].label,
+						title: template(this.options.tooltipTitleTemplate,ChartElements[0]),
 						chart: this.chart,
 						ctx: this.chart.ctx,
 						custom: this.options.customTooltips


### PR DESCRIPTION
Sometimes it's nice to show a different title in the tooltip than the x-label. For example, because there is more space than in the chart itself. Therefore, I have added this option.