### PR TITLE
Fixes #1393

### DIFF
--- a/src/scales/scale.category.js
+++ b/src/scales/scale.category.js
@@ -192,13 +192,14 @@
             if (this.isHorizontal()) {
                 minSize.width = maxWidth;
             } else if (this.options.display) {
-                minSize.width = Math.min(longestLabelWidth + 6, maxWidth);
+                var labelWidth = this.options.labels.show ? longestLabelWidth + 6 : 0;
+                minSize.width = Math.min(labelWidth, maxWidth);
             }
 
             // Height
             if (this.isHorizontal() && this.options.display) {
                 var labelHeight = (Math.sin(helpers.toRadians(this.labelRotation)) * longestLabelWidth) + 1.5 * this.options.labels.fontSize;
-                minSize.height = Math.min(labelHeight, maxHeight);
+                minSize.height = Math.min(this.options.labels.show ? labelHeight : 0, maxHeight);
             } else if (this.options.display) {
                 minSize.height = maxHeight;
             }

--- a/src/scales/scale.linear.js
+++ b/src/scales/scale.linear.js
@@ -172,7 +172,7 @@
 			} else {
 				// Bottom - top since pixels increase downard on a screen
 				var innerHeight = this.height - (this.paddingTop + this.paddingBottom);
-				pixel = this.bottom - (innerHeight / range * (value - this.start));
+				pixel = (this.bottom - this.paddingBottom) - (innerHeight / range * (value - this.start));
 				pixel += this.paddingTop;
 			}
 


### PR DESCRIPTION
Category scale now takes a smaller size if no labels are being displayed
Also updated linear scale code to use proper bottom padding. This is important when not displaying x axis labels