### PR TITLE
Only setLineDash if available

### DIFF
--- a/src/elements/element.line.js
+++ b/src/elements/element.line.js
@@ -114,7 +114,12 @@
 
 			// Now draw the line between all the points with any borders
 			ctx.lineCap = vm.borderCapStyle || Chart.defaults.global.elements.line.borderCapStyle;
-			ctx.setLineDash(vm.borderDash || Chart.defaults.global.elements.line.borderDash);
+			
+			// IE 9 and 10 do not support line dash
+			if (ctx.setLineDash) {
+				ctx.setLineDash(vm.borderDash || Chart.defaults.global.elements.line.borderDash);
+			}
+
 			ctx.lineDashOffset = vm.borderDashOffset || Chart.defaults.global.elements.line.borderDashOffset;
 			ctx.lineJoin = vm.borderJoinStyle || Chart.defaults.global.elements.line.borderJoinStyle;
 			ctx.lineWidth = vm.borderWidth || Chart.defaults.global.defaultColor;


### PR DESCRIPTION
IE9 and 10 do not support dashed lines. There is no workaround other than to ignore.