### PR TITLE
Allow hiding grid lines using the filter function in the category scale

### DIFF
--- a/docs/00-Getting-Started.md
+++ b/docs/00-Getting-Started.md
@@ -403,6 +403,9 @@ The `userCallback` method may be useful when there are a lot of labels. The foll
         xAxes: [{
             labels: {
                 maxRotation: 0,    // set maxRotation to 0 to turn off auto-rotation
+
+                // Return an empty string to draw the grid line but hide the label
+                // Return `null` or `undefined` to hide the grid line
                 userCallback: function(labelString, index) {
                     return (index % 5 === 0) ? labelString : '';
                 }

--- a/samples/line-x-axis-filter.html
+++ b/samples/line-x-axis-filter.html
@@ -55,7 +55,7 @@
                     display: true,
                     labels: {
                         userCallback: function(dataLabel, index) {
-                            return index % 2 === 0 ? dataLabel : '';
+                            return index % 2 === 0 ? dataLabel : null;
                         }
                     }
                 }],

--- a/src/scales/scale.category.js
+++ b/src/scales/scale.category.js
@@ -230,7 +230,8 @@
                     }
 
                     helpers.each(this.labels, function(label, index) {
-                        if (skipRatio > 1 && index % skipRatio > 0) {
+                        // Blank labels
+                        if ((skipRatio > 1 && index % skipRatio > 0) || (label === undefined || label === null)) {
                             return;
                         }
                         var xLineValue = this.getPixelForValue(label, index, null, false); // xvalues for grid lines


### PR DESCRIPTION
Category scale filter function will hide the grid line if `null` or `undefined` returned.

Updated the docs and the sample file. Fixes #1291 