### PR TITLE
Now allows hiding individual datasets

### DIFF
--- a/samples/bar.html
+++ b/samples/bar.html
@@ -45,6 +45,7 @@
                 backgroundColor: "rgba(220,220,220,0.5)",
                 data: [randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor()]
             }, {
+                hidden: true,
                 label: 'Dataset 2',
                 backgroundColor: "rgba(151,187,205,0.5)",
                 data: [randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor()]

--- a/samples/combo-bar-line.html
+++ b/samples/combo-bar-line.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-    <title>Bar Chart</title>
+    <title>Combo Bar-Line Chart</title>
     <script src="../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../Chart.js"></script>
 </head>
@@ -30,14 +30,14 @@
                 borderColor: 'white',
                 borderWidth: 2
             }, {
-                type: 'bar',
+                type: 'line',
                 label: 'Dataset 2',
                 backgroundColor: "rgba(151,187,205,0.5)",
                 data: [randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor()],
                 borderColor: 'white',
                 borderWidth: 2
             }, {
-                type: 'line',
+                type: 'bar',
                 label: 'Dataset 3',
                 backgroundColor: "rgba(220,220,220,0.5)",
                 data: [randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor()]

--- a/samples/doughnut.html
+++ b/samples/doughnut.html
@@ -61,6 +61,7 @@
                     "#4D5360",
                 ],
             }, {
+                hidden: true,
                 data: [
                     randomScalingFactor(),
                     randomScalingFactor(),

--- a/samples/line-x-axis-filter.html
+++ b/samples/line-x-axis-filter.html
@@ -54,8 +54,8 @@
                     xAxes: [{
                         display: true,
                         ticks: {
-                            callback: function(dataLabel, index) {
-                                return dataLabel;
+                            userCallback: function(dataLabel, index) {
+                                return index % 2 === 0 ? dataLabel : '';
                             }
                         }
                     }],

--- a/samples/line.html
+++ b/samples/line.html
@@ -49,6 +49,10 @@
                     fill: false,
                     borderDash: [5, 5],
                 }, {
+                    hidden: true,
+                    label: 'hidden dataset',
+                    data: [],
+                }, {
                     label: "My Second dataset",
                     data: [randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor()],
                 }]

--- a/samples/radar.html
+++ b/samples/radar.html
@@ -43,13 +43,17 @@
                 pointBackgroundColor: "rgba(220,220,220,1)",
                 data: [null, randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor()]
             }, {
+                label: 'Hidden dataset',
+                hidden: true,
+                data: [],
+            }, {
                 label: "My Second dataset",
                 backgroundColor: "rgba(151,187,205,0.2)",
                 pointBackgroundColor: "rgba(151,187,205,1)",
                 hoverPointBackgroundColor: "#fff",
                 pointHighlightStroke: "rgba(151,187,205,1)",
                 data: [null, randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor()]
-            }]
+            },]
         },
         options: {
             scale: {

--- a/src/controllers/controller.doughnut.js
+++ b/src/controllers/controller.doughnut.js
@@ -101,18 +101,35 @@
 			}
 		},
 
+		getVisibleDatasetCount: function getVisibleDatasetCount() {
+			return helpers.where(this.chart.data.datasets, function(ds) { return helpers.isDatasetVisible(ds); }).length;
+		},
+
+		// Get index of the dataset in relation to the visible datasets. This allows determining the inner and outer radius correctly
+		getRingIndex: function getRingIndex(datasetIndex) {
+			var ringIndex = 0;
+
+			for (var j = 0; j < datasetIndex; ++j) {
+				if (helpers.isDatasetVisible(this.chart.data.datasets[j])) {
+					++ringIndex;
+				}
+			}
+
+			return ringIndex;
+		},
+
 		update: function update(reset) {
 
 			this.chart.outerRadius = Math.max((helpers.min([this.chart.chart.width, this.chart.chart.height]) / 2) - this.chart.options.elements.arc.borderWidth / 2, 0);
 			this.chart.innerRadius = Math.max(this.chart.options.cutoutPercentage ? (this.chart.outerRadius / 100) * (this.chart.options.cutoutPercentage) : 1, 0);
-			this.chart.radiusLength = (this.chart.outerRadius - this.chart.innerRadius) / this.chart.data.datasets.length;
+			this.chart.radiusLength = (this.chart.outerRadius - this.chart.innerRadius) / this.getVisibleDatasetCount();
 
 			this.getDataset().total = 0;
 			helpers.each(this.getDataset().data, function(value) {
 				this.getDataset().total += Math.abs(value);
 			}, this);
 
-			this.outerRadius = this.chart.outerRadius - (this.chart.radiusLength * this.index);
+			this.outerRadius = this.chart.outerRadius - (this.chart.radiusLength * this.getRingIndex(this.index));
 			this.innerRadius = this.outerRadius - this.chart.radiusLength;
 
 			helpers.each(this.getDataset().metaData, function(arc, index) {

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -96,10 +96,14 @@
 			}
 		},
 
+		getVisibleDatasetCount: function getVisibleDatasetCount() {
+			return helpers.where(this.chart.data.datasets, function(ds) { return helpers.isDatasetVisible(ds); }).length;
+		},
+
 		update: function update(reset) {
 			this.chart.outerRadius = Math.max((helpers.min([this.chart.chart.width, this.chart.chart.height]) - this.chart.options.elements.arc.borderWidth / 2) / 2, 0);
 			this.chart.innerRadius = Math.max(this.chart.options.cutoutPercentage ? (this.chart.outerRadius / 100) * (this.chart.options.cutoutPercentage) : 1, 0);
-			this.chart.radiusLength = (this.chart.outerRadius - this.chart.innerRadius) / this.chart.data.datasets.length;
+			this.chart.radiusLength = (this.chart.outerRadius - this.chart.innerRadius) / this.getVisibleDatasetCount();
 
 			this.getDataset().total = 0;
 			helpers.each(this.getDataset().data, function(value) {

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -260,7 +260,9 @@
 
 			// Draw each dataset via its respective controller (reversed to support proper line stacking)
 			helpers.each(this.data.datasets, function(dataset, datasetIndex) {
-				dataset.controller.draw(ease);
+				if (helpers.isDatasetVisible(dataset)) {
+					dataset.controller.draw(ease);
+				}
 			}, this);
 
 			// Finally draw the tooltip
@@ -275,12 +277,14 @@
 			var elementsArray = [];
 
 			helpers.each(this.data.datasets, function(dataset, datasetIndex) {
-				helpers.each(dataset.metaData, function(element, index) {
-					if (element.inRange(eventPosition.x, eventPosition.y)) {
-						elementsArray.push(element);
-						return elementsArray;
-					}
-				}, this);
+				if (helpers.isDatasetVisible(dataset)) {
+					helpers.each(dataset.metaData, function(element, index) {
+						if (element.inRange(eventPosition.x, eventPosition.y)) {
+							elementsArray.push(element);
+							return elementsArray;
+						}
+					}, this);
+				}
 			}, this);
 
 			return elementsArray;
@@ -291,11 +295,13 @@
 			var elementsArray = [];
 
 			helpers.each(this.data.datasets, function(dataset, datasetIndex) {
-				helpers.each(dataset.metaData, function(element, index) {
-					if (element.inLabelRange(eventPosition.x, eventPosition.y)) {
-						elementsArray.push(element);
-					}
-				}, this);
+				if (helpers.isDatasetVisible(dataset)) {
+					helpers.each(dataset.metaData, function(element, index) {
+						if (element.inLabelRange(eventPosition.x, eventPosition.y)) {
+							elementsArray.push(element);
+						}
+					}, this);
+				}
 			}, this);
 
 			return elementsArray;
@@ -305,15 +311,17 @@
 			var eventPosition = helpers.getRelativePosition(e, this.chart);
 			var elementsArray = [];
 
-			for (var datasetIndex = 0; datasetIndex < this.data.datasets.length; datasetIndex++) {
-				for (var elementIndex = 0; elementIndex < this.data.datasets[datasetIndex].metaData.length; elementIndex++) {
-					if (this.data.datasets[datasetIndex].metaData[elementIndex].inLabelRange(eventPosition.x, eventPosition.y)) {
-						helpers.each(this.data.datasets[datasetIndex].metaData, function(element, index) {
-							elementsArray.push(element);
-						}, this);
+			helpers.each(this.data.datasets, function(dataset, datasetIndex) {
+				if (helpers.isDatasetVisible(dataset)) {
+					for (var elementIndex = 0; elementIndex < dataset.metaData.length; elementIndex++) {
+						if (dataset.metaData[elementIndex].inLabelRange(eventPosition.x, eventPosition.y)) {
+							helpers.each(dataset.metaData, function(element, index) {
+								elementsArray.push(element);
+							}, this);
+						}
 					}
 				}
-			}
+			}, this);
 
 			return elementsArray.length ? elementsArray : [];
 		},

--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -875,6 +875,8 @@
 				return Object.prototype.toString.call(arg) === '[object Array]';
 			}
 			return Array.isArray(obj);
+		},
+		isDatasetVisible = helpers.isDatasetVisible = function(dataset) {
+			return !dataset.hidden;
 		};
-
 }).call(this);

--- a/src/scales/scale.linear.js
+++ b/src/scales/scale.linear.js
@@ -21,7 +21,7 @@
 
 			if (this.options.stacked) {
 				helpers.each(this.data.datasets, function(dataset) {
-					if (this.isHorizontal() ? dataset.xAxisID === this.id : dataset.yAxisID === this.id) {
+					if (helpers.isDatasetVisible(dataset) && (this.isHorizontal() ? dataset.xAxisID === this.id : dataset.yAxisID === this.id)) {
 						helpers.each(dataset.data, function(rawValue, index) {
 
 							var value = this.getRightValue(rawValue);
@@ -48,7 +48,7 @@
 
 			} else {
 				helpers.each(this.data.datasets, function(dataset) {
-					if (this.isHorizontal() ? dataset.xAxisID === this.id : dataset.yAxisID === this.id) {
+					if (helpers.isDatasetVisible(dataset) && (this.isHorizontal() ? dataset.xAxisID === this.id : dataset.yAxisID === this.id)) {
 						helpers.each(dataset.data, function(rawValue, index) {
 							var value = this.getRightValue(rawValue);
 

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -26,7 +26,7 @@
 
 			if (this.options.stacked) {
 				helpers.each(this.data.datasets, function(dataset) {
-					if (this.isHorizontal() ? dataset.xAxisID === this.id : dataset.yAxisID === this.id) {
+					if (helpers.isDatasetVisible(dataset) && (this.isHorizontal() ? dataset.xAxisID === this.id : dataset.yAxisID === this.id)) {
 						helpers.each(dataset.data, function(rawValue, index) {
 
 							var value = this.getRightValue(rawValue);
@@ -48,7 +48,7 @@
 
 			} else {
 				helpers.each(this.data.datasets, function(dataset) {
-					if (this.isHorizontal() ? dataset.xAxisID === this.id : dataset.yAxisID === this.id) {
+					if (helpers.isDatasetVisible(dataset) && (this.isHorizontal() ? dataset.xAxisID === this.id : dataset.yAxisID === this.id)) {
 						helpers.each(dataset.data, function(rawValue, index) {
 							var value = this.getRightValue(rawValue);
 

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -68,21 +68,23 @@
 			this.max = null;
 
 			helpers.each(this.data.datasets, function(dataset) {
-				helpers.each(dataset.data, function(value, index) {
-					if (value === null) return;
+				if (helpers.isDatasetVisible(dataset)) {
+					helpers.each(dataset.data, function(value, index) {
+						if (value === null) return;
 
-					if (this.min === null) {
-						this.min = value;
-					} else if (value < this.min) {
-						this.min = value;
-					}
+						if (this.min === null) {
+							this.min = value;
+						} else if (value < this.min) {
+							this.min = value;
+						}
 
-					if (this.max === null) {
-						this.max = value;
-					} else if (value > this.max) {
-						this.max = value;
-					}
-				}, this);
+						if (this.max === null) {
+							this.max = value;
+						} else if (value > this.max) {
+							this.max = value;
+						}
+					}, this);
+				}
 			}, this);
 
 			if (this.min === this.max) {

--- a/test/controller.bar.tests.js
+++ b/test/controller.bar.tests.js
@@ -78,6 +78,39 @@ describe('Bar controller tests', function() {
 		expect(controller.getBarCount()).toBe(2);
 	});
 
+	it('should correctly get the bar index accounting for hidden datasets', function() {
+		var chart = {
+			data: {
+				datasets: [{
+					
+				}, {
+					hidden: true
+				}, {
+					type: 'line'
+				}, {
+					
+				}]
+			},
+			config: {
+				type: 'bar'
+			},
+			options: {
+				scales: {
+					xAxes: [{
+						id: 'firstXScaleID'
+					}],
+					yAxes: [{
+						id: 'firstYScaleID'
+					}]
+				}
+			}
+		};
+
+		var controller = new Chart.controllers.bar(chart, 1);
+		expect(controller.getBarIndex(0)).toBe(0);
+		expect(controller.getBarIndex(3)).toBe(1);
+	});
+
 	it('Should create rectangle elements for each data item during initialization', function() {
 		var chart = {
 			data: {

--- a/test/controller.doughnut.tests.js
+++ b/test/controller.doughnut.tests.js
@@ -68,6 +68,8 @@ describe('Doughnut controller tests', function() {
 			},
 			data: {
 				datasets: [{
+					hidden: true
+				}, {
 					data: [10, 15, 0, 4]
 				}, {
 					data: [1]
@@ -94,10 +96,10 @@ describe('Doughnut controller tests', function() {
 			}
 		};
 
-		var controller = new Chart.controllers.doughnut(chart, 0);
+		var controller = new Chart.controllers.doughnut(chart, 1);
 		controller.reset(); // reset first
 
-		expect(chart.data.datasets[0].metaData[0]._model).toEqual({
+		expect(chart.data.datasets[1].metaData[0]._model).toEqual({
 			x: 50,
 			y: 100,
 			startAngle: Math.PI * -0.5,
@@ -106,7 +108,7 @@ describe('Doughnut controller tests', function() {
 			innerRadius: 36.75,
 		});
 
-		expect(chart.data.datasets[0].metaData[1]._model).toEqual({
+		expect(chart.data.datasets[1].metaData[1]._model).toEqual({
 			x: 50,
 			y: 100,
 			startAngle: Math.PI * -0.5,
@@ -115,7 +117,7 @@ describe('Doughnut controller tests', function() {
 			innerRadius: 36.75,
 		});
 
-		expect(chart.data.datasets[0].metaData[2]._model).toEqual({
+		expect(chart.data.datasets[1].metaData[2]._model).toEqual({
 			x: 50,
 			y: 100,
 			startAngle: Math.PI * -0.5,
@@ -124,7 +126,7 @@ describe('Doughnut controller tests', function() {
 			innerRadius: 36.75,
 		});
 
-		expect(chart.data.datasets[0].metaData[3]._model).toEqual({
+		expect(chart.data.datasets[1].metaData[3]._model).toEqual({
 			x: 50,
 			y: 100,
 			startAngle: Math.PI * -0.5,
@@ -135,7 +137,7 @@ describe('Doughnut controller tests', function() {
 
 		controller.update();
 
-		expect(chart.data.datasets[0].metaData[0]._model).toEqual({
+		expect(chart.data.datasets[1].metaData[0]._model).toEqual({
 			x: 50,
 			y: 100,
 			startAngle: Math.PI * -0.5,
@@ -152,7 +154,7 @@ describe('Doughnut controller tests', function() {
 			label: 'label0',
 		});
 
-		expect(chart.data.datasets[0].metaData[1]._model).toEqual({
+		expect(chart.data.datasets[1].metaData[1]._model).toEqual({
 			x: 50,
 			y: 100,
 			startAngle: 0.5958182130626666,
@@ -169,7 +171,7 @@ describe('Doughnut controller tests', function() {
 			label: 'label1'
 		});
 
-		expect(chart.data.datasets[0].metaData[2]._model).toEqual({
+		expect(chart.data.datasets[1].metaData[2]._model).toEqual({
 			x: 50,
 			y: 100,
 			startAngle: 3.8457400228490113,
@@ -186,7 +188,7 @@ describe('Doughnut controller tests', function() {
 			label: 'label2'
 		});
 
-		expect(chart.data.datasets[0].metaData[3]._model).toEqual({
+		expect(chart.data.datasets[1].metaData[3]._model).toEqual({
 			x: 50,
 			y: 100,
 			startAngle: 3.8457400228490113,
@@ -204,24 +206,24 @@ describe('Doughnut controller tests', function() {
 		});
 
 		// Change the amount of data and ensure that arcs are updated accordingly
-		chart.data.datasets[0].data = [1, 2]; // remove 2 elements from dataset 0
+		chart.data.datasets[1].data = [1, 2]; // remove 2 elements from dataset 0
 		controller.buildOrUpdateElements();
 		controller.update();
 
-		expect(chart.data.datasets[0].metaData.length).toBe(2);
-		expect(chart.data.datasets[0].metaData[0] instanceof Chart.elements.Arc).toBe(true);
-		expect(chart.data.datasets[0].metaData[1] instanceof Chart.elements.Arc).toBe(true);
+		expect(chart.data.datasets[1].metaData.length).toBe(2);
+		expect(chart.data.datasets[1].metaData[0] instanceof Chart.elements.Arc).toBe(true);
+		expect(chart.data.datasets[1].metaData[1] instanceof Chart.elements.Arc).toBe(true);
 
 		// Add data
-		chart.data.datasets[0].data = [1, 2, 3, 4];
+		chart.data.datasets[1].data = [1, 2, 3, 4];
 		controller.buildOrUpdateElements();
 		controller.update();
 
-		expect(chart.data.datasets[0].metaData.length).toBe(4);
-		expect(chart.data.datasets[0].metaData[0] instanceof Chart.elements.Arc).toBe(true);
-		expect(chart.data.datasets[0].metaData[1] instanceof Chart.elements.Arc).toBe(true);
-		expect(chart.data.datasets[0].metaData[2] instanceof Chart.elements.Arc).toBe(true);
-		expect(chart.data.datasets[0].metaData[3] instanceof Chart.elements.Arc).toBe(true);
+		expect(chart.data.datasets[1].metaData.length).toBe(4);
+		expect(chart.data.datasets[1].metaData[0] instanceof Chart.elements.Arc).toBe(true);
+		expect(chart.data.datasets[1].metaData[1] instanceof Chart.elements.Arc).toBe(true);
+		expect(chart.data.datasets[1].metaData[2] instanceof Chart.elements.Arc).toBe(true);
+		expect(chart.data.datasets[1].metaData[3] instanceof Chart.elements.Arc).toBe(true);
 	});
 
 	it ('should draw all arcs', function() {

--- a/test/scale.linear.tests.js
+++ b/test/scale.linear.tests.js
@@ -84,6 +84,44 @@ describe('Linear Scale', function() {
 		expect(scale.max).toBe(150);
 	});
 
+	it('Should correctly determine the max & min data values ignoring hidden datasets', function() {
+		var scaleID = 'myScale';
+
+		var mockData = {
+			datasets: [{
+				yAxisID: scaleID,
+				data: [10, 5, 0, -5, 78, -100]
+			}, {
+				yAxisID: 'second scale',
+				data: [-1000, 1000],
+			}, {
+				yAxisID: scaleID,
+				data: [150],
+				hidden: true
+			}]
+		};
+
+		var Constructor = Chart.scaleService.getScaleConstructor('linear');
+		var scale = new Constructor({
+			ctx: {},
+			options: Chart.scaleService.getScaleDefaults('linear'), // use default config for scale
+			data: mockData,
+			id: scaleID
+		});
+
+		expect(scale).not.toEqual(undefined); // must construct
+		expect(scale.min).toBe(undefined); // not yet set
+		expect(scale.max).toBe(undefined);
+
+		// Set arbitrary width and height for now
+		scale.width = 50;
+		scale.height = 400;
+
+		scale.buildTicks();
+		expect(scale.min).toBe(-100);
+		expect(scale.max).toBe(80);
+	});
+
 	it('Should correctly determine the max & min for scatter data', function() {
 		var scaleID = 'myScale';
 
@@ -155,6 +193,46 @@ describe('Linear Scale', function() {
 			}, {
 				yAxisID: scaleID,
 				data: [150, 0, 0, -100, -10, 9]
+			}]
+		};
+
+		var config = Chart.helpers.clone(Chart.scaleService.getScaleDefaults('linear'));
+		config.stacked = true; // enable scale stacked mode
+
+		var Constructor = Chart.scaleService.getScaleConstructor('linear');
+		var scale = new Constructor({
+			ctx: {},
+			options: config,
+			data: mockData,
+			id: scaleID
+		});
+
+		// Set arbitrary width and height for now
+		scale.width = 50;
+		scale.height = 400;
+
+		scale.buildTicks();
+		expect(scale.min).toBe(-150);
+		expect(scale.max).toBe(200);
+	});
+
+	it('Should correctly determine the min and max data values when stacked mode is turned on and there are hidden datasets', function() {
+		var scaleID = 'myScale';
+
+		var mockData = {
+			datasets: [{
+				yAxisID: scaleID,
+				data: [10, 5, 0, -5, 78, -100]
+			}, {
+				yAxisID: 'second scale',
+				data: [-1000, 1000],
+			}, {
+				yAxisID: scaleID,
+				data: [150, 0, 0, -100, -10, 9]
+			}, {
+				yAxisID: scaleID,
+				data: [10, 20, 30, 40, 50, 60],
+				hidden: true
 			}]
 		};
 

--- a/test/scale.logarithmic.tests.js
+++ b/test/scale.logarithmic.tests.js
@@ -80,6 +80,41 @@ describe('Logarithmic Scale tests', function() {
 		expect(scale.max).toBe(10000);
 	});
 
+	it('Should correctly determine the max & min data values when there are hidden datasets', function() {
+		var scaleID = 'myScale';
+
+		var mockData = {
+			datasets: [{
+				yAxisID: scaleID,
+				data: [10, 5, 5000, 78, 450]
+			}, {
+				yAxisID: 'second scale',
+				data: [1, 1000, 10, 100],
+			}, {
+				yAxisID: scaleID,
+				data: [50000],
+				hidden: true
+			}]
+		};
+
+		var mockContext = window.createMockContext();
+		var Constructor = Chart.scaleService.getScaleConstructor('logarithmic');
+		var scale = new Constructor({
+			ctx: mockContext,
+			options: Chart.scaleService.getScaleDefaults('logarithmic'), // use default config for scale
+			data: mockData,
+			id: scaleID
+		});
+
+		expect(scale).not.toEqual(undefined); // must construct
+		expect(scale.min).toBe(undefined); // not yet set
+		expect(scale.max).toBe(undefined);
+
+		scale.update(400, 400);
+		expect(scale.min).toBe(1);
+		expect(scale.max).toBe(10000);
+	});
+
 	it('Should correctly determine the max & min for scatter data', function() {
 		var scaleID = 'myScale';
 
@@ -144,6 +179,43 @@ describe('Logarithmic Scale tests', function() {
 			}, {
 				yAxisID: scaleID,
 				data: [150, 10, 10, 100, 10, 9]
+			}]
+		};
+
+		var config = Chart.helpers.clone(Chart.scaleService.getScaleDefaults('logarithmic'));
+		config.stacked = true; // enable scale stacked mode
+
+		var mockContext = window.createMockContext();
+		var Constructor = Chart.scaleService.getScaleConstructor('logarithmic');
+		var scale = new Constructor({
+			ctx: mockContext,
+			options: config,
+			data: mockData,
+			id: scaleID
+		});
+
+		scale.update(400, 400);
+		expect(scale.min).toBe(10);
+		expect(scale.max).toBe(1000);
+	});
+
+	it('Should correctly determine the min and max data values when stacked mode is turned on ignoring hidden datasets', function() {
+		var scaleID = 'myScale';
+
+		var mockData = {
+			datasets: [{
+				yAxisID: scaleID,
+				data: [10, 5, 1, 5, 78, 100]
+			}, {
+				yAxisID: 'second scale',
+				data: [-1000, 1000],
+			}, {
+				yAxisID: scaleID,
+				data: [150, 10, 10, 100, 10, 9]
+			}, {
+				yAxisID: scaleID,
+				data: [10000, 10000, 10000, 10000, 10000, 10000],
+				hidden: true
 			}]
 		};
 

--- a/test/scale.radialLinear.tests.js
+++ b/test/scale.radialLinear.tests.js
@@ -92,6 +92,38 @@ describe('Test the radial linear scale', function() {
 		expect(scale.max).toBe(200);
 	});
 
+	it('Should correctly determine the max & min data values when there are hidden datasets', function() {
+		var scaleID = 'myScale';
+
+		var mockData = {
+			datasets: [{
+				yAxisID: scaleID,
+				data: [10, 5, 0, -5, 78, -100]
+			}, {
+				yAxisID: scaleID,
+				data: [150]
+			}, {
+				yAxisID: scaleID,
+				data: [1000],
+				hidden: true
+			}],
+			labels: ['lablel1', 'label2', 'label3', 'label4', 'label5', 'label6']
+		};
+
+		var mockContext = window.createMockContext();
+		var Constructor = Chart.scaleService.getScaleConstructor('radialLinear');
+		var scale = new Constructor({
+			ctx: mockContext,
+			options: Chart.scaleService.getScaleDefaults('radialLinear'), // use default config for scale
+			data: mockData,
+			id: scaleID,
+		});
+
+		scale.update(200, 300);
+		expect(scale.min).toBe(-100);
+		expect(scale.max).toBe(200);
+	});
+
 	it('Should ensure that the scale has a max and min that are not equal', function() {
 		var scaleID = 'myScale';
 


### PR DESCRIPTION
To hide a dataset, simply define a property `hidden` on a dataset. Call `update` to refresh the chart and the dataset is gone. Hidden datasets are not drawn, nor is their data considered when calculating scale sizes. 

A number of samples have been updated to include hidden datasets.