### PR TITLE
Tooltip constructor to receive the instance of the Element

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -1103,7 +1103,7 @@
 						title: template(this.options.tooltipTitleTemplate,ChartElements[0]),
 						chart: this.chart,
 						ctx: this.chart.ctx,
-            			element: Element,
+            					element: Element,
 						custom: this.options.customTooltips
 					}).draw();
 
@@ -1124,7 +1124,7 @@
 							cornerRadius: this.options.tooltipCornerRadius,
 							text: template(this.options.tooltipTemplate, Element),
 							chart: this.chart,
-              				element: Element,
+              						element: Element,
 							custom: this.options.customTooltips
 						}).draw();
 					}, this);

--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -1103,7 +1103,7 @@
 						title: template(this.options.tooltipTitleTemplate,ChartElements[0]),
 						chart: this.chart,
 						ctx: this.chart.ctx,
-            element: Element,
+            			element: Element,
 						custom: this.options.customTooltips
 					}).draw();
 
@@ -1124,7 +1124,7 @@
 							cornerRadius: this.options.tooltipCornerRadius,
 							text: template(this.options.tooltipTemplate, Element),
 							chart: this.chart,
-              element: Element,
+              				element: Element,
 							custom: this.options.customTooltips
 						}).draw();
 					}, this);

--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -1103,6 +1103,7 @@
 						title: template(this.options.tooltipTitleTemplate,ChartElements[0]),
 						chart: this.chart,
 						ctx: this.chart.ctx,
+            element: Element,
 						custom: this.options.customTooltips
 					}).draw();
 
@@ -1123,6 +1124,7 @@
 							cornerRadius: this.options.tooltipCornerRadius,
 							text: template(this.options.tooltipTemplate, Element),
 							chart: this.chart,
+              element: Element,
 							custom: this.options.customTooltips
 						}).draw();
 					}, this);


### PR DESCRIPTION
I recommend we pass the *currently* hovered element to the Tooltip constructor so that anyone with a customTooltips implementation can leverage the element to their advantage.

I am implementing a custom legend, where  I highlight the legend text when I hover on the corresponding pie of the Pie chart.
