### PR TITLE
Fix mistaken variable assignment in core files

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -4,7 +4,7 @@
 
 	//Declare root variable - window in the browser, global on the server
 	var root = this,
-		previous = root.Chart,
+		Chart = root.Chart,
 		helpers = Chart.helpers;
 
 

--- a/src/core/core.element.js
+++ b/src/core/core.element.js
@@ -4,7 +4,7 @@
 
 	//Declare root variable - window in the browser, global on the server
 	var root = this,
-		previous = root.Chart,
+		Chart = root.Chart,
 		helpers = Chart.helpers;
 
 	Chart.elements = {};

--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -4,7 +4,7 @@
 
 	//Declare root variable - window in the browser, global on the server
 	var root = this,
-		previous = root.Chart;
+		Chart = root.Chart;
 
 	//Global Chart helpers object for utility methods and classes
 	var helpers = Chart.helpers = {};


### PR DESCRIPTION
Three core files assigned `root.Chart` to `previous` rather than `Chart`.

This PR fixes #1269.