### PR TITLE
V2.0 dev skip null fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,5 @@ script:
 
 notifications:
   slack: chartjs:pcfCZR6ugg5TEcaLtmIfQYuA
+
+sudo: false

--- a/src/controllers/controller.bubble.js
+++ b/src/controllers/controller.bubble.js
@@ -169,12 +169,13 @@
 					backgroundColor: point.custom && point.custom.backgroundColor ? point.custom.backgroundColor : helpers.getValueAtIndexOrDefault(this.getDataset().backgroundColor, index, this.chart.options.elements.point.backgroundColor),
 					borderColor: point.custom && point.custom.borderColor ? point.custom.borderColor : helpers.getValueAtIndexOrDefault(this.getDataset().borderColor, index, this.chart.options.elements.point.borderColor),
 					borderWidth: point.custom && point.custom.borderWidth ? point.custom.borderWidth : helpers.getValueAtIndexOrDefault(this.getDataset().borderWidth, index, this.chart.options.elements.point.borderWidth),
-					skip: point.custom && point.custom.skip ? point.custom.skip : this.getDataset().data[index] === null,
 
 					// Tooltip
 					hitRadius: point.custom && point.custom.hitRadius ? point.custom.hitRadius : helpers.getValueAtIndexOrDefault(this.getDataset().hitRadius, index, this.chart.options.elements.point.hitRadius),
 				},
 			});
+
+			point._model.skip = point.custom && point.custom.skip ? point.custom.skip : (isNaN(point._model.x) || isNaN(point._model.y));
 
 			point.pivot();
 		},

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -153,8 +153,6 @@
 					borderDashOffset: line.custom && line.custom.borderDashOffset ? line.custom.borderDashOffset : (this.getDataset().borderDashOffset || this.chart.options.elements.line.borderDashOffset),
 					borderJoinStyle: line.custom && line.custom.borderJoinStyle ? line.custom.borderJoinStyle : (this.getDataset().borderJoinStyle || this.chart.options.elements.line.borderJoinStyle),
 					fill: line.custom && line.custom.fill ? line.custom.fill : (this.getDataset().fill !== undefined ? this.getDataset().fill : this.chart.options.elements.line.fill),
-					skipNull: this.getDataset().skipNull !== undefined ? this.getDataset().skipNull : this.chart.options.elements.line.skipNull,
-					drawNull: this.getDataset().drawNull !== undefined ? this.getDataset().drawNull : this.chart.options.elements.line.drawNull,
 					// Scale
 					scaleTop: yScale.top,
 					scaleBottom: yScale.bottom,
@@ -202,12 +200,12 @@
 					backgroundColor: point.custom && point.custom.backgroundColor ? point.custom.backgroundColor : helpers.getValueAtIndexOrDefault(this.getDataset().pointBackgroundColor, index, this.chart.options.elements.point.backgroundColor),
 					borderColor: point.custom && point.custom.borderColor ? point.custom.borderColor : helpers.getValueAtIndexOrDefault(this.getDataset().pointBorderColor, index, this.chart.options.elements.point.borderColor),
 					borderWidth: point.custom && point.custom.borderWidth ? point.custom.borderWidth : helpers.getValueAtIndexOrDefault(this.getDataset().pointBorderWidth, index, this.chart.options.elements.point.borderWidth),
-					skip: point.custom && point.custom.skip ? point.custom.skip : this.getDataset().data[index] === null,
-
 					// Tooltip
 					hitRadius: point.custom && point.custom.hitRadius ? point.custom.hitRadius : helpers.getValueAtIndexOrDefault(this.getDataset().hitRadius, index, this.chart.options.elements.point.hitRadius),
 				},
 			});
+
+			point._model.skip = point.custom && point.custom.skip ? point.custom.skip : (isNaN(point._model.x) || isNaN(point._model.y));
 		},
 
 		updateBezierControlPoints: function() {

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -141,8 +141,6 @@
 					borderWidth: this.getDataset().borderWidth || this.chart.options.elements.line.borderWidth,
 					borderColor: this.getDataset().borderColor || this.chart.options.elements.line.borderColor,
 					fill: this.getDataset().fill !== undefined ? this.getDataset().fill : this.chart.options.elements.line.fill, // use the value from the this.getDataset() if it was provided. else fall back to the default
-					skipNull: this.getDataset().skipNull !== undefined ? this.getDataset().skipNull : this.chart.options.elements.line.skipNull,
-					drawNull: this.getDataset().drawNull !== undefined ? this.getDataset().drawNull : this.chart.options.elements.line.drawNull,
 
 					// Scale
 					scaleTop: scale.top,
@@ -181,12 +179,13 @@
 					backgroundColor: point.custom && point.custom.backgroundColor ? point.custom.backgroundColor : helpers.getValueAtIndexOrDefault(this.getDataset().pointBackgroundColor, index, this.chart.options.elements.point.backgroundColor),
 					borderColor: point.custom && point.custom.borderColor ? point.custom.borderColor : helpers.getValueAtIndexOrDefault(this.getDataset().pointBorderColor, index, this.chart.options.elements.point.borderColor),
 					borderWidth: point.custom && point.custom.borderWidth ? point.custom.borderWidth : helpers.getValueAtIndexOrDefault(this.getDataset().pointBorderWidth, index, this.chart.options.elements.point.borderWidth),
-					skip: point.custom && point.custom.skip ? point.custom.skip : this.getDataset().data[index] === null,
 
 					// Tooltip
 					hitRadius: point.custom && point.custom.hitRadius ? point.custom.hitRadius : helpers.getValueAtIndexOrDefault(this.getDataset().hitRadius, index, this.chart.options.elements.point.hitRadius),
 				},
 			});
+
+			point._model.skip = point.custom && point.custom.skip ? point.custom.skip : (isNaN(point._model.x) || isNaN(point._model.y));
 		},
 		updateBezierControlPoints: function() {
 			helpers.each(this.getDataset().metaData, function(point, index) {

--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -324,18 +324,32 @@
 		splineCurve = helpers.splineCurve = function(FirstPoint, MiddlePoint, AfterPoint, t) {
 			//Props to Rob Spencer at scaled innovation for his post on splining between points
 			//http://scaledinnovation.com/analytics/splines/aboutSplines.html
-			var d01 = Math.sqrt(Math.pow(MiddlePoint.x - FirstPoint.x, 2) + Math.pow(MiddlePoint.y - FirstPoint.y, 2)),
-				d12 = Math.sqrt(Math.pow(AfterPoint.x - MiddlePoint.x, 2) + Math.pow(AfterPoint.y - MiddlePoint.y, 2)),
+
+			// This function must also respect "skipped" points
+
+			var previous = FirstPoint,
+				current = MiddlePoint,
+				next = AfterPoint;
+
+			if (previous.skip) {
+				previous = current;
+			}
+			if (next.skip) {
+				next = current;
+			}
+
+			var d01 = Math.sqrt(Math.pow(current.x - previous.x, 2) + Math.pow(current.y - previous.y, 2)),
+				d12 = Math.sqrt(Math.pow(next.x - current.x, 2) + Math.pow(next.y - current.y, 2)),
 				fa = t * d01 / (d01 + d12), // scaling factor for triangle Ta
 				fb = t * d12 / (d01 + d12);
 			return {
 				previous: {
-					x: MiddlePoint.x - fa * (AfterPoint.x - FirstPoint.x),
-					y: MiddlePoint.y - fa * (AfterPoint.y - FirstPoint.y)
+					x: current.x - fa * (next.x - previous.x),
+					y: current.y - fa * (next.y - previous.y)
 				},
 				next: {
-					x: MiddlePoint.x + fb * (AfterPoint.x - FirstPoint.x),
-					y: MiddlePoint.y + fb * (AfterPoint.y - FirstPoint.y)
+					x: current.x + fb * (next.x - previous.x),
+					y: current.y + fb * (next.y - previous.y)
 				}
 			};
 		},

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -317,11 +317,22 @@
 		},
 
 		// Get the correct value. NaN bad inputs, If the value type is object get the x or y based on whether we are horizontal or not
-		getRightValue: function(rawValue) {
-			if (isNaN(rawValue) || rawValue === null || typeof(rawValue) === 'undefined') {
+		getRightValue: function getRightValue(rawValue) {
+			// Null and undefined values first
+			if (rawValue === null || typeof(rawValue) === 'undefined') {
 				return NaN;
 			}
-			return typeof(rawValue) === "object" ? (this.isHorizontal() ? rawValue.x : rawValue.y) : rawValue;
+			// isNaN(object) returns true, so make sure NaN is checking for a number
+			if (typeof(rawValue) === 'number' && isNaN(rawValue)) {
+				return NaN;
+			}
+			// If it is in fact an object, dive in one more level
+			if (typeof(rawValue) === "object") {
+				return getRightValue(this.isHorizontal() ? rawValue.x : rawValue.y);
+			}
+
+			// Value is good, return it
+			return rawValue;
 		},
 
 		// Used to get the value to display in the tooltip for the data at the given index

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -315,10 +315,13 @@
 		isHorizontal: function() {
 			return this.options.position == "top" || this.options.position == "bottom";
 		},
-		
-		// Get the correct value. If the value type is object get the x or y based on whether we are horizontal or not
+
+		// Get the correct value. NaN bad inputs, If the value type is object get the x or y based on whether we are horizontal or not
 		getRightValue: function(rawValue) {
-			return (typeof(rawValue) === "object" && rawValue !== null) ? (this.isHorizontal() ? rawValue.x : rawValue.y) : rawValue;
+			if (isNaN(rawValue) || rawValue === null || typeof(rawValue) === 'undefined') {
+				return NaN;
+			}
+			return typeof(rawValue) === "object" ? (this.isHorizontal() ? rawValue.x : rawValue.y) : rawValue;
 		},
 
 		// Used to get the value to display in the tooltip for the data at the given index

--- a/src/scales/scale.linear.js
+++ b/src/scales/scale.linear.js
@@ -25,6 +25,9 @@
 						helpers.each(dataset.data, function(rawValue, index) {
 
 							var value = this.getRightValue(rawValue);
+							if (isNaN(value)) {
+								return;
+							}
 
 							positiveValues[index] = positiveValues[index] || 0;
 							negativeValues[index] = negativeValues[index] || 0;
@@ -51,6 +54,9 @@
 					if (helpers.isDatasetVisible(dataset) && (this.isHorizontal() ? dataset.xAxisID === this.id : dataset.yAxisID === this.id)) {
 						helpers.each(dataset.data, function(rawValue, index) {
 							var value = this.getRightValue(rawValue);
+							if (isNaN(value)) {
+								return;
+							}
 
 							if (this.min === null) {
 								this.min = value;
@@ -155,17 +161,18 @@
 		getPixelForValue: function(value, index, datasetIndex, includeOffset) {
 			// This must be called after fit has been run so that 
 			//      this.left, this.top, this.right, and this.bottom have been defined
+			var rightValue = this.getRightValue(value);
 			var pixel;
 			var range = this.end - this.start;
 
 			if (this.isHorizontal()) {
 
 				var innerWidth = this.width - (this.paddingLeft + this.paddingRight);
-				pixel = this.left + (innerWidth / range * (this.getRightValue(value) - this.start));
+				pixel = this.left + (innerWidth / range * (rightValue - this.start));
 				return Math.round(pixel + this.paddingLeft);
 			} else {
 				var innerHeight = this.height - (this.paddingTop + this.paddingBottom);
-				pixel = (this.bottom - this.paddingBottom) - (innerHeight / range * (this.getRightValue(value) - this.start));
+				pixel = (this.bottom - this.paddingBottom) - (innerHeight / range * (rightValue - this.start));
 				return Math.round(pixel);
 			}
 		},

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -14,7 +14,7 @@
 				var remain = value / (Math.pow(10, Math.floor(Chart.helpers.log10(value))));
 
 				if (remain === 1 || remain === 2 || remain === 5) {
-					return value.toExponential()
+					return value.toExponential();
 				} else {
 					return '';
 				}
@@ -38,6 +38,9 @@
 						helpers.each(dataset.data, function(rawValue, index) {
 
 							var value = this.getRightValue(rawValue);
+							if (isNaN(value)) {
+								return;
+							}
 
 							values[index] = values[index] || 0;
 
@@ -59,6 +62,9 @@
 					if (helpers.isDatasetVisible(dataset) && (this.isHorizontal() ? dataset.xAxisID === this.id : dataset.yAxisID === this.id)) {
 						helpers.each(dataset.data, function(rawValue, index) {
 							var value = this.getRightValue(rawValue);
+							if (isNaN(value)) {
+								return;
+							}
 
 							if (this.min === null) {
 								this.min = value;

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -69,8 +69,11 @@
 
 			helpers.each(this.data.datasets, function(dataset) {
 				if (helpers.isDatasetVisible(dataset)) {
-					helpers.each(dataset.data, function(value, index) {
-						if (value === null) return;
+					helpers.each(dataset.data, function(rawValue, index) {
+						var value = this.getRightValue(rawValue);
+						if (isNaN(value)) {
+							return;
+						}
 
 						if (this.min === null) {
 							this.min = value;

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -280,8 +280,8 @@
 		getPointPosition: function(index, distanceFromCenter) {
 			var thisAngle = this.getIndexAngle(index);
 			return {
-				x: (Math.cos(thisAngle) * distanceFromCenter) + this.xCenter,
-				y: (Math.sin(thisAngle) * distanceFromCenter) + this.yCenter
+				x: Math.round(Math.cos(thisAngle) * distanceFromCenter) + this.xCenter,
+				y: Math.round(Math.sin(thisAngle) * distanceFromCenter) + this.yCenter
 			};
 		},
 		getPointPositionForValue: function(index, value) {

--- a/test/controller.line.tests.js
+++ b/test/controller.line.tests.js
@@ -103,7 +103,7 @@ describe('Line controller tests', function() {
 		expect(chart.data.datasets[0].metaData.length).toBe(3);
 	});
 
-	it ('should draw all elements', function() {
+	it('should draw all elements', function() {
 		var chart = {
 			data: {
 				datasets: [{
@@ -141,7 +141,7 @@ describe('Line controller tests', function() {
 		expect(chart.data.datasets[0].metaData[3].draw.calls.count()).toBe(1);
 	});
 
-	it ('should update elements', function() {
+	it('should update elements', function() {
 		var data = {
 			datasets: [{
 				data: [10, 15, 0, -4],
@@ -210,7 +210,6 @@ describe('Line controller tests', function() {
 						borderJoinStyle: 'bevel',
 						borderWidth: 1.2,
 						fill: true,
-						skipNull: true,
 						tension: 0.1,
 					},
 					point: {
@@ -251,8 +250,6 @@ describe('Line controller tests', function() {
 			borderJoinStyle: 'bevel',
 			borderWidth: 1.2,
 			fill: true,
-			drawNull: undefined,
-			skipNull: true,
 			tension: 0.1,
 
 			scaleTop: 0,
@@ -268,7 +265,7 @@ describe('Line controller tests', function() {
 			radius: 3,
 			skip: false,
 			tension: 0.1,
-			
+
 			// Point
 			x: 71,
 			y: 62,
@@ -288,7 +285,7 @@ describe('Line controller tests', function() {
 			radius: 3,
 			skip: false,
 			tension: 0.1,
-			
+
 			// Point
 			x: 121,
 			y: 15,
@@ -308,7 +305,7 @@ describe('Line controller tests', function() {
 			radius: 3,
 			skip: false,
 			tension: 0.1,
-			
+
 			// Point
 			x: 172,
 			y: 156,
@@ -328,7 +325,7 @@ describe('Line controller tests', function() {
 			radius: 3,
 			skip: false,
 			tension: 0.1,
-			
+
 			// Point
 			x: 222,
 			y: 194,
@@ -350,8 +347,6 @@ describe('Line controller tests', function() {
 		chart.data.datasets[0].borderDashOffset = 7;
 		chart.data.datasets[0].borderJoinStyle = 'miter';
 		chart.data.datasets[0].fill = false;
-		chart.data.datasets[0].skipNull = false;
-		chart.data.datasets[0].drawNull = true;
 
 		// point styles
 		chart.data.datasets[0].radius = 22;
@@ -371,8 +366,6 @@ describe('Line controller tests', function() {
 			borderJoinStyle: 'miter',
 			borderWidth: 0.55,
 			fill: false,
-			drawNull: true,
-			skipNull: false,
 			tension: 0.2,
 
 			scaleTop: 0,
@@ -388,7 +381,7 @@ describe('Line controller tests', function() {
 			radius: 22,
 			skip: false,
 			tension: 0.2,
-			
+
 			// Point
 			x: 71,
 			y: 62,
@@ -408,7 +401,7 @@ describe('Line controller tests', function() {
 			radius: 22,
 			skip: false,
 			tension: 0.2,
-			
+
 			// Point
 			x: 121,
 			y: 15,
@@ -428,7 +421,7 @@ describe('Line controller tests', function() {
 			radius: 22,
 			skip: false,
 			tension: 0.2,
-			
+
 			// Point
 			x: 172,
 			y: 156,
@@ -448,7 +441,7 @@ describe('Line controller tests', function() {
 			radius: 22,
 			skip: false,
 			tension: 0.2,
-			
+
 			// Point
 			x: 222,
 			y: 194,
@@ -471,8 +464,6 @@ describe('Line controller tests', function() {
 			borderDashOffset: 4.4,
 			borderJoinStyle: 'round',
 			fill: true,
-			skipNull: true,
-			drawNull: false,
 		};
 
 		// point styles
@@ -497,8 +488,6 @@ describe('Line controller tests', function() {
 			borderJoinStyle: 'round',
 			borderWidth: 0.3,
 			fill: true,
-			drawNull: true,
-			skipNull: false,
 			tension: 0.25,
 
 			scaleTop: 0,
@@ -514,7 +503,7 @@ describe('Line controller tests', function() {
 			radius: 2.2,
 			skip: true,
 			tension: 0.15,
-			
+
 			// Point
 			x: 71,
 			y: 62,
@@ -527,7 +516,7 @@ describe('Line controller tests', function() {
 		});
 	});
 
-	it ('should handle number of data point changes in update', function() {
+	it('should handle number of data point changes in update', function() {
 		var data = {
 			datasets: [{
 				data: [10, 15, 0, -4],
@@ -596,7 +585,6 @@ describe('Line controller tests', function() {
 						borderJoinStyle: 'bevel',
 						borderWidth: 1.2,
 						fill: true,
-						skipNull: true,
 						tension: 0.1,
 					},
 					point: {
@@ -643,7 +631,7 @@ describe('Line controller tests', function() {
 		expect(chart.data.datasets[0].metaData[4] instanceof Chart.elements.Point).toBe(true);
 	});
 
-	it ('should set point hover styles', function() {
+	it('should set point hover styles', function() {
 		var data = {
 			datasets: [{
 				data: [10, 15, 0, -4],
@@ -777,7 +765,7 @@ describe('Line controller tests', function() {
 		expect(point._model.radius).toBe(4.4);
 	});
 
-	it ('should remove hover styles', function() {
+	it('should remove hover styles', function() {
 		var data = {
 			datasets: [{
 				data: [10, 15, 0, -4],
@@ -846,7 +834,6 @@ describe('Line controller tests', function() {
 						borderJoinStyle: 'bevel',
 						borderWidth: 1.2,
 						fill: true,
-						skipNull: true,
 						tension: 0.1,
 					},
 					point: {

--- a/test/element.line.tests.js
+++ b/test/element.line.tests.js
@@ -1,6 +1,6 @@
 // Tests for the line element
 describe('Line element tests', function() {
-	it ('should be constructed', function() {
+	it('should be constructed', function() {
 		var line = new Chart.elements.Line({
 			_datasetindex: 2,
 			_points: [1, 2, 3, 4]
@@ -11,7 +11,7 @@ describe('Line element tests', function() {
 		expect(line._points).toEqual([1, 2, 3, 4]);
 	});
 
-	it ('should draw with default settings', function() {
+	it('should draw with default settings', function() {
 		var mockContext = window.createMockContext();
 
 		// Create our points
@@ -21,7 +21,7 @@ describe('Line element tests', function() {
 			_index: 0,
 			_view: {
 				x: 0,
-				y: 10
+				y: 10,
 			}
 		}));
 		points.push(new Chart.elements.Point({
@@ -29,7 +29,7 @@ describe('Line element tests', function() {
 			_index: 1,
 			_view: {
 				x: 5,
-				y: 0
+				y: 0,
 			}
 		}));
 		points.push(new Chart.elements.Point({
@@ -37,7 +37,7 @@ describe('Line element tests', function() {
 			_index: 2,
 			_view: {
 				x: 15,
-				y: -10
+				y: -10,
 			}
 		}));
 		points.push(new Chart.elements.Point({
@@ -45,7 +45,7 @@ describe('Line element tests', function() {
 			_index: 3,
 			_view: {
 				x: 19,
-				y: -5
+				y: -5,
 			}
 		}));
 
@@ -59,8 +59,9 @@ describe('Line element tests', function() {
 			_view: {
 				fill: false, // don't want to fill
 				tension: 0.0, // no bezier curve for now
+				scaleZero: 0
 			}
-		})
+		});
 
 		line.draw();
 
@@ -69,6 +70,9 @@ describe('Line element tests', function() {
 			args: [],
 		}, {
 			name: 'moveTo',
+			args: [0, 0]
+		}, {
+			name: 'lineTo',
 			args: [0, 10]
 		}, {
 			name: 'lineTo',
@@ -84,7 +88,9 @@ describe('Line element tests', function() {
 			args: ['butt']
 		}, {
 			name: 'setLineDash',
-			args: [[]]
+			args: [
+				[]
+			]
 		}, {
 			name: 'setLineDashOffset',
 			args: [0.0]
@@ -102,6 +108,9 @@ describe('Line element tests', function() {
 			args: []
 		}, {
 			name: 'moveTo',
+			args: [0, 0]
+		}, {
+			name: 'lineTo',
 			args: [0, 10]
 		}, {
 			name: 'lineTo',
@@ -118,10 +127,10 @@ describe('Line element tests', function() {
 		}, {
 			name: 'restore',
 			args: []
-		}])
+		}]);
 	});
 
-	it ('should draw with custom settings', function() {
+	it('should draw with custom settings', function() {
 		var mockContext = window.createMockContext();
 
 		// Create our points
@@ -167,7 +176,7 @@ describe('Line element tests', function() {
 			_children: points,
 			// Need to provide some settings
 			_view: {
-				fill: true, 
+				fill: true,
 				scaleZero: 2, // for filling lines
 				tension: 0.0, // no bezier curve for now
 
@@ -179,7 +188,7 @@ describe('Line element tests', function() {
 				borderWidth: 4,
 				backgroundColor: 'rgb(0, 0, 0)'
 			}
-		})
+		});
 
 		line.draw();
 
@@ -188,6 +197,9 @@ describe('Line element tests', function() {
 			args: [],
 		}, {
 			name: 'moveTo',
+			args: [0, 2]
+		}, {
+			name: 'lineTo',
 			args: [0, 10]
 		}, {
 			name: 'lineTo',
@@ -218,7 +230,9 @@ describe('Line element tests', function() {
 			args: ['round']
 		}, {
 			name: 'setLineDash',
-			args: [[2, 2]]
+			args: [
+				[2, 2]
+			]
 		}, {
 			name: 'setLineDashOffset',
 			args: [1.5]
@@ -236,6 +250,9 @@ describe('Line element tests', function() {
 			args: []
 		}, {
 			name: 'moveTo',
+			args: [0, 2]
+		}, {
+			name: 'lineTo',
 			args: [0, 10]
 		}, {
 			name: 'lineTo',
@@ -253,10 +270,10 @@ describe('Line element tests', function() {
 			name: 'restore',
 			args: []
 		}];
-		expect(mockContext.getCalls()).toEqual(expected)
+		expect(mockContext.getCalls()).toEqual(expected);
 	});
 
-	it ('should be able to draw with a loop back to the beginning point', function() {
+	it('should be able to draw with a loop back to the beginning point', function() {
 		var mockContext = window.createMockContext();
 
 		// Create our points
@@ -305,8 +322,9 @@ describe('Line element tests', function() {
 			_view: {
 				fill: false, // don't want to fill
 				tension: 0.0, // no bezier curve for now
+				scaleZero: 0,
 			}
-		})
+		});
 
 		line.draw();
 
@@ -315,6 +333,9 @@ describe('Line element tests', function() {
 			args: [],
 		}, {
 			name: 'moveTo',
+			args: [0, 0]
+		}, {
+			name: 'lineTo',
 			args: [0, 10]
 		}, {
 			name: 'lineTo',
@@ -333,7 +354,9 @@ describe('Line element tests', function() {
 			args: ['butt']
 		}, {
 			name: 'setLineDash',
-			args: [[]]
+			args: [
+				[]
+			]
 		}, {
 			name: 'setLineDashOffset',
 			args: [0.0]
@@ -351,6 +374,9 @@ describe('Line element tests', function() {
 			args: []
 		}, {
 			name: 'moveTo',
+			args: [0, 0]
+		}, {
+			name: 'lineTo',
 			args: [0, 10]
 		}, {
 			name: 'lineTo',
@@ -370,10 +396,10 @@ describe('Line element tests', function() {
 		}, {
 			name: 'restore',
 			args: []
-		}])
+		}]);
 	});
 
-	it ('should draw with bezier curves if tension > 0', function() {
+	it('should draw with bezier curves if tension > 0', function() {
 		var mockContext = window.createMockContext();
 
 		// Create our points
@@ -435,7 +461,7 @@ describe('Line element tests', function() {
 			_children: points,
 			// Need to provide some settings
 			_view: {
-				fill: true, 
+				fill: true,
 				scaleZero: 2, // for filling lines
 				tension: 0.5, // have bezier curves
 
@@ -447,7 +473,7 @@ describe('Line element tests', function() {
 				borderWidth: 4,
 				backgroundColor: 'rgb(0, 0, 0)'
 			}
-		})
+		});
 
 		line.draw();
 
@@ -456,6 +482,9 @@ describe('Line element tests', function() {
 			args: [],
 		}, {
 			name: 'moveTo',
+			args: [0, 2]
+		}, {
+			name: 'lineTo',
 			args: [0, 10]
 		}, {
 			name: 'bezierCurveTo',
@@ -486,7 +515,9 @@ describe('Line element tests', function() {
 			args: ['round']
 		}, {
 			name: 'setLineDash',
-			args: [[2, 2]]
+			args: [
+				[2, 2]
+			]
 		}, {
 			name: 'setLineDashOffset',
 			args: [1.5]
@@ -504,6 +535,9 @@ describe('Line element tests', function() {
 			args: []
 		}, {
 			name: 'moveTo',
+			args: [0, 2]
+		}, {
+			name: 'lineTo',
 			args: [0, 10]
 		}, {
 			name: 'bezierCurveTo',
@@ -521,6 +555,6 @@ describe('Line element tests', function() {
 			name: 'restore',
 			args: []
 		}];
-		expect(mockContext.getCalls()).toEqual(expected)
+		expect(mockContext.getCalls()).toEqual(expected);
 	});
 });

--- a/test/scale.radialLinear.tests.js
+++ b/test/scale.radialLinear.tests.js
@@ -275,7 +275,7 @@ describe('Test the radial linear scale', function() {
 		scale.bottom = 305;
 		scale.update(200, 300);
 
-		expect(scale.drawingArea).toBe(36);
+		expect(scale.drawingArea).toBe(37);
 		expect(scale.xCenter).toBe(110);
 		expect(scale.yCenter).toBe(155);
 	});
@@ -308,17 +308,17 @@ describe('Test the radial linear scale', function() {
 		scale.update(200, 300);
 
 		expect(scale.getDistanceFromCenterForValue(scale.min)).toBe(0);
-		expect(scale.getDistanceFromCenterForValue(scale.max)).toBe(36);
+		expect(scale.getDistanceFromCenterForValue(scale.max)).toBe(37);
 		expect(scale.getPointPositionForValue(1, 5)).toEqual({
-			x: 102.13987716166409,
-			y: 149.30471176265638,
+			x: 102,
+			y: 149,
 		});
 
 		config.reverse = true;
 
 		scale.update(200, 300);
 
-		expect(scale.getDistanceFromCenterForValue(scale.min)).toBe(36);
+		expect(scale.getDistanceFromCenterForValue(scale.min)).toBe(37);
 		expect(scale.getDistanceFromCenterForValue(scale.max)).toBe(0);
 	});
 
@@ -384,7 +384,7 @@ describe('Test the radial linear scale', function() {
 			"args": []
 		}, {
 			"name": "arc",
-			"args": [100, 150, 9, 0, 6.283185307179586]
+			"args": [100, 150, 9.25, 0, 6.283185307179586]
 		}, {
 			"name": "closePath",
 			"args": []
@@ -399,13 +399,13 @@ describe('Test the radial linear scale', function() {
 			"args": ["rgba(255,255,255,0.75)"]
 		}, {
 			"name": "fillRect",
-			"args": [88, 133, 24, 16]
+			"args": [88, 132.75, 24, 16]
 		}, {
 			"name": "setFillStyle",
 			"args": ["#666"]
 		}, {
 			"name": "fillText",
-			"args": ["20", 100, 141]
+			"args": ["20", 100, 140.75]
 		}, {
 			"name": "setStrokeStyle",
 			"args": ["rgba(0, 0, 0, 0.1)"]
@@ -417,7 +417,7 @@ describe('Test the radial linear scale', function() {
 			"args": []
 		}, {
 			"name": "arc",
-			"args": [100, 150, 18, 0, 6.283185307179586]
+			"args": [100, 150, 18.5, 0, 6.283185307179586]
 		}, {
 			"name": "closePath",
 			"args": []
@@ -432,13 +432,13 @@ describe('Test the radial linear scale', function() {
 			"args": ["rgba(255,255,255,0.75)"]
 		}, {
 			"name": "fillRect",
-			"args": [88, 124, 24, 16]
+			"args": [88, 123.5, 24, 16]
 		}, {
 			"name": "setFillStyle",
 			"args": ["#666"]
 		}, {
 			"name": "fillText",
-			"args": ["40", 100, 132]
+			"args": ["40", 100, 131.5]
 		}, {
 			"name": "setStrokeStyle",
 			"args": ["rgba(0, 0, 0, 0.1)"]
@@ -450,7 +450,7 @@ describe('Test the radial linear scale', function() {
 			"args": []
 		}, {
 			"name": "arc",
-			"args": [100, 150, 27, 0, 6.283185307179586]
+			"args": [100, 150, 27.75, 0, 6.283185307179586]
 		}, {
 			"name": "closePath",
 			"args": []
@@ -465,13 +465,13 @@ describe('Test the radial linear scale', function() {
 			"args": ["rgba(255,255,255,0.75)"]
 		}, {
 			"name": "fillRect",
-			"args": [88, 115, 24, 16]
+			"args": [88, 114.25, 24, 16]
 		}, {
 			"name": "setFillStyle",
 			"args": ["#666"]
 		}, {
 			"name": "fillText",
-			"args": ["60", 100, 123]
+			"args": ["60", 100, 122.25]
 		}, {
 			"name": "setStrokeStyle",
 			"args": ["rgba(0, 0, 0, 0.1)"]
@@ -483,7 +483,7 @@ describe('Test the radial linear scale', function() {
 			"args": []
 		}, {
 			"name": "arc",
-			"args": [100, 150, 36, 0, 6.283185307179586]
+			"args": [100, 150, 37, 0, 6.283185307179586]
 		}, {
 			"name": "closePath",
 			"args": []
@@ -498,13 +498,13 @@ describe('Test the radial linear scale', function() {
 			"args": ["rgba(255,255,255,0.75)"]
 		}, {
 			"name": "fillRect",
-			"args": [88, 106, 24, 16]
+			"args": [88, 105, 24, 16]
 		}, {
 			"name": "setFillStyle",
 			"args": ["#666"]
 		}, {
 			"name": "fillText",
-			"args": ["80", 100, 114]
+			"args": ["80", 100, 113]
 		}];
 		expect(mockContext.getCalls()).toEqual(expected);
 
@@ -526,16 +526,16 @@ describe('Test the radial linear scale', function() {
 			"args": [100, 141]
 		}, {
 			"name": "lineTo",
-			"args": [108.55950864665638, 147.21884705062547]
+			"args": [109, 147]
 		}, {
 			"name": "lineTo",
-			"args": [105.29006727063226, 157.28115294937453]
+			"args": [105, 157]
 		}, {
 			"name": "lineTo",
-			"args": [94.70993272936774, 157.28115294937453]
+			"args": [95, 157]
 		}, {
 			"name": "lineTo",
-			"args": [91.44049135334362, 147.21884705062547]
+			"args": [91, 147]
 		}, {
 			"name": "closePath",
 			"args": []
@@ -550,13 +550,13 @@ describe('Test the radial linear scale', function() {
 			"args": ["rgba(255,255,255,0.75)"]
 		}, {
 			"name": "fillRect",
-			"args": [88, 133, 24, 16]
+			"args": [88, 132.75, 24, 16]
 		}, {
 			"name": "setFillStyle",
 			"args": ["#666"]
 		}, {
 			"name": "fillText",
-			"args": ["20", 100, 141]
+			"args": ["20", 100, 140.75]
 		}, {
 			"name": "setStrokeStyle",
 			"args": ["rgba(0, 0, 0, 0.1)"]
@@ -571,16 +571,16 @@ describe('Test the radial linear scale', function() {
 			"args": [100, 132]
 		}, {
 			"name": "lineTo",
-			"args": [117.11901729331277, 144.43769410125094]
+			"args": [118, 144]
 		}, {
 			"name": "lineTo",
-			"args": [110.58013454126451, 164.56230589874906]
+			"args": [111, 165]
 		}, {
 			"name": "lineTo",
-			"args": [89.41986545873549, 164.56230589874906]
+			"args": [89, 165]
 		}, {
 			"name": "lineTo",
-			"args": [82.88098270668723, 144.43769410125094]
+			"args": [82, 144]
 		}, {
 			"name": "closePath",
 			"args": []
@@ -595,13 +595,13 @@ describe('Test the radial linear scale', function() {
 			"args": ["rgba(255,255,255,0.75)"]
 		}, {
 			"name": "fillRect",
-			"args": [88, 124, 24, 16]
+			"args": [88, 123.5, 24, 16]
 		}, {
 			"name": "setFillStyle",
 			"args": ["#666"]
 		}, {
 			"name": "fillText",
-			"args": ["40", 100, 132]
+			"args": ["40", 100, 131.5]
 		}, {
 			"name": "setStrokeStyle",
 			"args": ["rgba(0, 0, 0, 0.1)"]
@@ -613,19 +613,19 @@ describe('Test the radial linear scale', function() {
 			"args": []
 		}, {
 			"name": "moveTo",
-			"args": [100, 123]
+			"args": [100, 122]
 		}, {
 			"name": "lineTo",
-			"args": [125.67852593996915, 141.6565411518764]
+			"args": [126, 141]
 		}, {
 			"name": "lineTo",
-			"args": [115.87020181189678, 171.8434588481236]
+			"args": [116, 172]
 		}, {
 			"name": "lineTo",
-			"args": [84.12979818810322, 171.8434588481236]
+			"args": [84, 172]
 		}, {
 			"name": "lineTo",
-			"args": [74.32147406003085, 141.6565411518764]
+			"args": [74, 141]
 		}, {
 			"name": "closePath",
 			"args": []
@@ -640,13 +640,13 @@ describe('Test the radial linear scale', function() {
 			"args": ["rgba(255,255,255,0.75)"]
 		}, {
 			"name": "fillRect",
-			"args": [88, 115, 24, 16]
+			"args": [88, 114.25, 24, 16]
 		}, {
 			"name": "setFillStyle",
 			"args": ["#666"]
 		}, {
 			"name": "fillText",
-			"args": ["60", 100, 123]
+			"args": ["60", 100, 122.25]
 		}, {
 			"name": "setStrokeStyle",
 			"args": ["rgba(0, 0, 0, 0.1)"]
@@ -658,19 +658,19 @@ describe('Test the radial linear scale', function() {
 			"args": []
 		}, {
 			"name": "moveTo",
-			"args": [100, 114]
+			"args": [100, 113]
 		}, {
 			"name": "lineTo",
-			"args": [134.23803458662553, 138.87538820250188]
+			"args": [135, 139]
 		}, {
 			"name": "lineTo",
-			"args": [121.16026908252903, 179.12461179749812]
+			"args": [122, 180]
 		}, {
 			"name": "lineTo",
-			"args": [78.83973091747097, 179.12461179749812]
+			"args": [78, 180]
 		}, {
 			"name": "lineTo",
-			"args": [65.76196541337447, 138.8753882025019]
+			"args": [65, 139]
 		}, {
 			"name": "closePath",
 			"args": []
@@ -685,13 +685,13 @@ describe('Test the radial linear scale', function() {
 			"args": ["rgba(255,255,255,0.75)"]
 		}, {
 			"name": "fillRect",
-			"args": [88, 106, 24, 16]
+			"args": [88, 105, 24, 16]
 		}, {
 			"name": "setFillStyle",
 			"args": ["#666"]
 		}, {
 			"name": "fillText",
-			"args": ["80", 100, 114]
+			"args": ["80", 100, 113]
 		}, {
 			"name": "setLineWidth",
 			"args": [1]
@@ -706,7 +706,7 @@ describe('Test the radial linear scale', function() {
 			"args": [100, 150]
 		}, {
 			"name": "lineTo",
-			"args": [65.76196541337447, 138.8753882025019]
+			"args": [65, 139]
 		}, {
 			"name": "stroke",
 			"args": []
@@ -718,7 +718,7 @@ describe('Test the radial linear scale', function() {
 			"args": ["#666"]
 		}, {
 			"name": "fillText",
-			"args": ["point5", 61.0066828318987, 137.33030323062715]
+			"args": ["point5", 60, 137]
 		}, {
 			"name": "beginPath",
 			"args": []
@@ -727,7 +727,7 @@ describe('Test the radial linear scale', function() {
 			"args": [100, 150]
 		}, {
 			"name": "lineTo",
-			"args": [78.83973091747097, 179.12461179749812]
+			"args": [78, 180]
 		}, {
 			"name": "stroke",
 			"args": []
@@ -739,7 +739,7 @@ describe('Test the radial linear scale', function() {
 			"args": ["#666"]
 		}, {
 			"name": "fillText",
-			"args": ["point4", 75.9008046560086, 183.16969676937285]
+			"args": ["point4", 75, 184]
 		}, {
 			"name": "beginPath",
 			"args": []
@@ -748,7 +748,7 @@ describe('Test the radial linear scale', function() {
 			"args": [100, 150]
 		}, {
 			"name": "lineTo",
-			"args": [121.16026908252903, 179.12461179749812]
+			"args": [122, 180]
 		}, {
 			"name": "stroke",
 			"args": []
@@ -760,7 +760,7 @@ describe('Test the radial linear scale', function() {
 			"args": ["#666"]
 		}, {
 			"name": "fillText",
-			"args": ["point3", 124.0991953439914, 183.16969676937285]
+			"args": ["point3", 125, 184]
 		}, {
 			"name": "beginPath",
 			"args": []
@@ -769,7 +769,7 @@ describe('Test the radial linear scale', function() {
 			"args": [100, 150]
 		}, {
 			"name": "lineTo",
-			"args": [134.23803458662553, 138.87538820250188]
+			"args": [135, 139]
 		}, {
 			"name": "stroke",
 			"args": []
@@ -781,7 +781,7 @@ describe('Test the radial linear scale', function() {
 			"args": ["#666"]
 		}, {
 			"name": "fillText",
-			"args": ["point2", 138.9933171681013, 137.33030323062715]
+			"args": ["point2", 140, 137]
 		}, {
 			"name": "beginPath",
 			"args": []
@@ -790,7 +790,7 @@ describe('Test the radial linear scale', function() {
 			"args": [100, 150]
 		}, {
 			"name": "lineTo",
-			"args": [100, 114]
+			"args": [100, 113]
 		}, {
 			"name": "stroke",
 			"args": []
@@ -802,7 +802,7 @@ describe('Test the radial linear scale', function() {
 			"args": ["#666"]
 		}, {
 			"name": "fillText",
-			"args": ["point1", 100, 109]
+			"args": ["point1", 100, 108]
 		}]);
 	});
 });


### PR DESCRIPTION
This fixes bad values from killing the chart.  `NaN`, `undefined`, and `null` are now all treated the same.

`skipNull` and `drawNull` are no longer options in the line element.  There weren’t used much, because quite frankly, they didn’t work!  Now it’s all automagical, and bad values won’t be drawn.

You can still manually skip a point by marking that point’s `_model` with a `skip: true` property.