### PR TITLE
Better linear scale tick formatter + small tick generation

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -138,7 +138,7 @@
 					if (this.options.ticks.userCallback) {
 						return this.options.ticks.userCallback(numericalTick, index, ticks);
 					}
-					return this.options.ticks.callback(numericalTick);
+					return this.options.ticks.callback(numericalTick, index, ticks);
 				},
 				this);
 		},

--- a/src/scales/scale.linear.js
+++ b/src/scales/scale.linear.js
@@ -7,6 +7,32 @@
 
 	var defaultConfig = {
 		position: "left",
+		ticks: {
+			callback: function(tickValue, index, ticks) {
+				var delta = ticks[1] - ticks[0];
+
+				// If we have a number like 2.5 as the delta, figure out how many decimal places we need
+				if (Math.abs(delta) > 1) {
+					if (tickValue !== Math.floor(tickValue)) {
+						// not an integer
+						delta = tickValue - Math.floor(tickValue);
+					}
+				}
+
+				var logDelta = helpers.log10(Math.abs(delta));
+				var tickString = '';
+
+				if (tickValue !== 0) {
+					var numDecimal = -1 * Math.floor(logDelta);
+					numDecimal = Math.max(Math.min(numDecimal, 20), 0); // toFixed has a max of 20 decimal places
+					tickString = tickValue.toFixed(numDecimal);
+				} else {
+					tickString = '0'; // never show decimal places for 0
+				}
+
+				return tickString;
+			}
+		}
 	};
 
 	var LinearScale = Chart.Scale.extend({
@@ -119,9 +145,11 @@
 			var niceMin = Math.floor(this.min / spacing) * spacing;
 			var niceMax = Math.ceil(this.max / spacing) * spacing;
 
+			var numSpaces = Math.ceil((niceMax - niceMin) / spacing);
+
 			// Put the values into the ticks array
-			for (var j = niceMin; j <= niceMax; j += spacing) {
-				this.ticks.push(j);
+			for (var j = 0; j <= numSpaces; ++j) {
+				this.ticks.push(niceMin + (j * spacing));
 			}
 
 			if (this.options.position == "left" || this.options.position == "right") {

--- a/test/controller.bar.tests.js
+++ b/test/controller.bar.tests.js
@@ -262,7 +262,7 @@ describe('Bar controller tests', function() {
 		expect(bar1._xScale).toBe(chart.scales.firstXScaleID);
 		expect(bar1._yScale).toBe(chart.scales.firstYScaleID);
 		expect(bar1._model).toEqual({
-			x: 113.60000000000001,
+			x: 103.60000000000001,
 			y: 194,
 			label: 'label1',
 			datasetLabel: 'dataset2',
@@ -279,8 +279,8 @@ describe('Bar controller tests', function() {
 		expect(bar2._xScale).toBe(chart.scales.firstXScaleID);
 		expect(bar2._yScale).toBe(chart.scales.firstYScaleID);
 		expect(bar2._model).toEqual({
-			x: 151.60000000000002,
-			y: -15,
+			x: 141.6,
+			y: 6,
 			label: 'label2',
 			datasetLabel: 'dataset2',
 

--- a/test/scale.linear.tests.js
+++ b/test/scale.linear.tests.js
@@ -412,6 +412,31 @@ describe('Linear Scale', function() {
 		expect(scale.ticks).toEqual(['80', '70', '60', '50', '40', '30', '20', '10', '0']);
 	});
 
+	it('should use the correct number of decimal places in the default format function', function() {
+		var scaleID = 'myScale';
+
+		var mockData = {
+			datasets: [{
+				yAxisID: scaleID,
+				data: [0.06, 0.005, 0, 0.025, 0.0078]
+			}, ]
+		};
+
+		var mockContext = window.createMockContext();
+		var config = Chart.helpers.clone(Chart.scaleService.getScaleDefaults('linear'));
+		var Constructor = Chart.scaleService.getScaleConstructor('linear');
+		var scale = new Constructor({
+			ctx: mockContext,
+			options: config,
+			data: mockData,
+			id: scaleID
+		});
+
+		// Set arbitrary width and height for now
+		scale.update(50, 400);
+		expect(scale.ticks).toEqual(['0.06', '0.05', '0.04', '0.03', '0.02', '0.01', '0']);
+	});
+
 	it('Should build labels using the user supplied callback', function() {
 		var scaleID = 'myScale';
 
@@ -423,7 +448,7 @@ describe('Linear Scale', function() {
 		};
 
 		var config = Chart.helpers.clone(Chart.scaleService.getScaleDefaults('linear'));
-		config.ticks.userCallback = function(value, index) {
+		config.ticks.callback = function(value, index) {
 			return index.toString();
 		};
 


### PR DESCRIPTION
This should fix #1498 

Rather than simply calling `toString` we try to figure out the optimal number of decimal places and then call `toFixed` instead. 