### PR TITLE
Change license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ For support using Chart.js, please post questions with the [`chartjs` tag on Sta
 
 ## License
 
-Chart.js is available under the [MIT license](http://opensource.org/licenses/MIT).
+Chart.js is available under the [MIT license](https://github.com/nnnick/Chart.js/blob/master/LICENSE.md).


### PR DESCRIPTION
The link to the license now points to the direct license that applies for chart.js, rather than a generic MIT license