### PR TITLE
Improve v2.0.0-beta0 tooltips

### DIFF
--- a/src/controllers/controller.doughnut.js
+++ b/src/controllers/controller.doughnut.js
@@ -18,6 +18,16 @@
 		},
 		//The percentage of the chart that we cut out of the middle.
 		cutoutPercentage: 50,
+
+		// Need to override these to give a nice default
+		tooltips: {
+			callbacks: {
+				title: function() { return '' },
+				label: function(tooltipItem, data) {
+					return data.labels[tooltipItem.index] + ': ' + data.datasets[tooltipItem.datasetIndex].data[tooltipItem.index];
+				}
+			}
+		}
 	};
 
 	Chart.defaults.pie = helpers.clone(Chart.defaults.doughnut);

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -17,6 +17,16 @@
 		//Boolean - Whether to animate the rotation of the chart
 		animateRotate: true,
 		animateScale: true,
+
+		// Need to override these to give a nice default
+		tooltips: {
+			callbacks: {
+				title: function() { return '' },
+				label: function(tooltipItem, data) {
+					return data.labels[tooltipItem.index] + ': ' + tooltipItem.yLabel;
+				}
+			}
+		}
 	};
 
 	Chart.controllers.polarArea = function(chart, datasetIndex) {
@@ -143,6 +153,7 @@
 				_chart: this.chart.chart,
 				_datasetIndex: this.index,
 				_index: index,
+				_scale: this.chart.scale,
 
 				// Desired view properties
 				_model: reset ? resetModel : {

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -167,6 +167,7 @@
 				// Utility
 				_datasetIndex: this.index,
 				_index: index,
+				_scale: this.chart.scale,
 
 				// Desired view properties
 				_model: {

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -42,7 +42,17 @@
 			beforeTitle: helpers.noop,
 			title: function(tooltipItems, data) {
 				// Pick first xLabel for now
-				return tooltipItems.length > 0 ? tooltipItems[0].xLabel : '';
+				var title = '';
+
+				if (tooltipItems.length > 0) {
+					if (tooltipItems[0].xLabel) {
+						title = tooltipItems[0].xLabel;
+					} else if (data.labels.length > 0 && tooltipItems[0].index < data.labels.length) {
+						title = data.labels[tooltipItems[0].index];
+					}
+				}
+
+				return title;
 			},
 			afterTitle: helpers.noop,
 
@@ -194,9 +204,10 @@
 			var tooltipItems = [];
 
 			if (this._options.tooltips.mode == 'single') {
+				var yScale = element._yScale || element._scale; // handle radar || polarArea charts
 				tooltipItems.push({
 					xLabel: element._xScale ? element._xScale.getLabelForIndex(element._index, element._datasetIndex) : '',
-					yLabel: element._yScale ? element._yScale.getLabelForIndex(element._index, element._datasetIndex) : '',
+					yLabel: yScale ? yScale.getLabelForIndex(element._index, element._datasetIndex) : '',
 					index: element._index,
 					datasetIndex: element._datasetIndex,
 				});
@@ -207,10 +218,11 @@
 						return;
 					}
 					var currentElement = dataset.metaData[element._index];
+					var yScale = element._yScale || element._scale; // handle radar || polarArea charts
 
 					tooltipItems.push({
 						xLabel: currentElement._xScale ? currentElement._xScale.getLabelForIndex(currentElement._index, currentElement._datasetIndex) : '',
-						yLabel: currentElement._yScale ? currentElement._yScale.getLabelForIndex(currentElement._index, currentElement._datasetIndex) : '',
+						yLabel: yScale ? yScale.getLabelForIndex(currentElement._index, currentElement._datasetIndex) : '',
 						index: element._index,
 						datasetIndex: datasetIndex,
 					});

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -104,9 +104,9 @@
 					bodyColor: options.tooltips.bodyColor,
 					_bodyFontFamily: options.tooltips.bodyFontFamily,
 					_bodyFontStyle: options.tooltips.bodyFontStyle,
+					_bodyAlign: options.tooltips.bodyAlign,
 					bodyFontSize: options.tooltips.bodyFontSize,
 					bodySpacing: options.tooltips.bodySpacing,
-					_bodposition: options.tooltips.bodposition,
 
 					// Title
 					titleColor: options.tooltips.titleColor,

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -151,6 +151,9 @@
 
 			this.zeroLineIndex = this.ticks.indexOf(0);
 		},
+		getLabelForIndex: function(index, datasetIndex) {
+			return this.getRightValue(this.data.datasets[datasetIndex].data[index]);
+		},
 		getCircumference: function() {
 			return ((Math.PI * 2) / this.getValueCount());
 		},


### PR DESCRIPTION
This fixes #1583 and #1584

## Bar Chart Tooltip
![screen shot 2015-10-30 at 9 09 52 pm](https://cloud.githubusercontent.com/assets/6757853/10861072/cfc51d88-7f4a-11e5-836a-b71a45e9f0a0.png)

## Line Chart Tooltip
![screen shot 2015-10-30 at 9 10 07 pm](https://cloud.githubusercontent.com/assets/6757853/10861075/d7aa3c9a-7f4a-11e5-8c7a-c7bad921ebfa.png)

## Radar Chart Tooltip
![screen shot 2015-10-30 at 9 10 21 pm](https://cloud.githubusercontent.com/assets/6757853/10861076/e14d0688-7f4a-11e5-8ba8-badfc9603ca3.png)

## Polar Area Chart Tooltip
![screen shot 2015-10-30 at 9 10 28 pm](https://cloud.githubusercontent.com/assets/6757853/10861078/ea371054-7f4a-11e5-8b01-791dd4a31bd7.png)

## Doughnut Chart Tooltip
![screen shot 2015-10-30 at 9 10 36 pm](https://cloud.githubusercontent.com/assets/6757853/10861079/f14b8a46-7f4a-11e5-946d-770617cbb635.png)
