### PR TITLE
Fixed stacked scale calculation for combo charts

### DIFF
--- a/src/scales/scale.linear.js
+++ b/src/scales/scale.linear.js
@@ -83,8 +83,10 @@
 
 				helpers.each(valuesPerType, function(valuesForType) {
 					var values = valuesForType.positiveValues.concat(valuesForType.negativeValues);
-					this.min = Math.min(this.min, helpers.min(values));
-					this.max = Math.max(this.max, helpers.max(values));
+					var minVal = helpers.min(values);
+					var maxVal = helpers.max(values);
+					this.min = this.min === null ? minVal : Math.min(this.min, minVal);
+					this.max = this.max === null ? maxVal : Math.max(this.max, maxVal);
 				}, this);
 
 			} else {

--- a/src/scales/scale.linear.js
+++ b/src/scales/scale.linear.js
@@ -42,11 +42,21 @@
 			this.min = null;
 			this.max = null;
 
-			var positiveValues = [];
-			var negativeValues = [];
-
 			if (this.options.stacked) {
+				var valuesPerType = {};
+
 				helpers.each(this.data.datasets, function(dataset) {
+					if (valuesPerType[dataset.type] === undefined) {
+						valuesPerType[dataset.type] = {
+							positiveValues: [],
+							negativeValues: [],
+						};
+					}
+
+					// Store these per type
+					var positiveValues = valuesPerType[dataset.type].positiveValues;
+					var negativeValues = valuesPerType[dataset.type].negativeValues;
+
 					if (helpers.isDatasetVisible(dataset) && (this.isHorizontal() ? dataset.xAxisID === this.id : dataset.yAxisID === this.id)) {
 						helpers.each(dataset.data, function(rawValue, index) {
 
@@ -71,9 +81,11 @@
 					}
 				}, this);
 
-				var values = positiveValues.concat(negativeValues);
-				this.min = helpers.min(values);
-				this.max = helpers.max(values);
+				helpers.each(valuesPerType, function(valuesForType) {
+					var values = valuesForType.positiveValues.concat(valuesForType.negativeValues);
+					this.min = Math.min(this.min, helpers.min(values));
+					this.max = Math.max(this.max, helpers.max(values));
+				}, this);
 
 			} else {
 				helpers.each(this.data.datasets, function(dataset) {

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -30,13 +30,17 @@
 			this.min = null;
 			this.max = null;
 
-			var values = [];
-
 			if (this.options.stacked) {
+				var valuesPerType = {};
+
 				helpers.each(this.data.datasets, function(dataset) {
 					if (helpers.isDatasetVisible(dataset) && (this.isHorizontal() ? dataset.xAxisID === this.id : dataset.yAxisID === this.id)) {
-						helpers.each(dataset.data, function(rawValue, index) {
+						if (valuesPerType[dataset.type] === undefined) {
+							valuesPerType[dataset.type] = [];
+						}
 
+						helpers.each(dataset.data, function(rawValue, index) {
+							var values = valuesPerType[dataset.type];
 							var value = this.getRightValue(rawValue);
 							if (isNaN(value)) {
 								return;
@@ -54,8 +58,12 @@
 					}
 				}, this);
 
-				this.min = helpers.min(values);
-				this.max = helpers.max(values);
+				helpers.each(valuesPerType, function(valuesForType) {
+					var minVal = helpers.min(valuesForType);
+					var maxVal = helpers.max(valuesForType);
+					this.min = this.min === null ? minVal : Math.min(this.min, minVal);
+					this.max = this.max === null ? maxVal : Math.max(this.max, maxVal);
+				}, this);
 
 			} else {
 				helpers.each(this.data.datasets, function(dataset) {

--- a/test/scale.linear.tests.js
+++ b/test/scale.linear.tests.js
@@ -188,13 +188,19 @@ describe('Linear Scale', function() {
 		var mockData = {
 			datasets: [{
 				yAxisID: scaleID,
-				data: [10, 5, 0, -5, 78, -100]
+				data: [10, 5, 0, -5, 78, -100],
+				type: 'bar'
 			}, {
 				yAxisID: 'second scale',
 				data: [-1000, 1000],
 			}, {
 				yAxisID: scaleID,
-				data: [150, 0, 0, -100, -10, 9]
+				data: [150, 0, 0, -100, -10, 9],
+				type: 'bar'
+			}, {
+				yAxisID: scaleID,
+				data: [10, 10, 10, 10, 10, 10],
+				type: 'line'
 			}]
 		};
 

--- a/test/scale.logarithmic.tests.js
+++ b/test/scale.logarithmic.tests.js
@@ -175,13 +175,19 @@ describe('Logarithmic Scale tests', function() {
 		var mockData = {
 			datasets: [{
 				yAxisID: scaleID,
-				data: [10, 5, 1, 5, 78, 100]
+				data: [10, 5, 1, 5, 78, 100],
+				type: 'bar'
 			}, {
 				yAxisID: 'second scale',
 				data: [-1000, 1000],
 			}, {
 				yAxisID: scaleID,
-				data: [150, 10, 10, 100, 10, 9]
+				data: [150, 10, 10, 100, 10, 9],
+				type: 'bar'
+			}, {
+				yAxisID: scaleID,
+				data: [100, 100, 100, 100, 100, 100],
+				type: 'line'
 			}]
 		};
 
@@ -208,17 +214,21 @@ describe('Logarithmic Scale tests', function() {
 		var mockData = {
 			datasets: [{
 				yAxisID: scaleID,
-				data: [10, 5, 1, 5, 78, 100]
+				data: [10, 5, 1, 5, 78, 100],
+				type: 'bar'
 			}, {
 				yAxisID: 'second scale',
 				data: [-1000, 1000],
+				type: 'bar'
 			}, {
 				yAxisID: scaleID,
-				data: [150, 10, 10, 100, 10, 9]
+				data: [150, 10, 10, 100, 10, 9],
+				type: 'bar'
 			}, {
 				yAxisID: scaleID,
 				data: [10000, 10000, 10000, 10000, 10000, 10000],
-				hidden: true
+				hidden: true,
+				type: 'bar'
 			}]
 		};
 


### PR DESCRIPTION
Previously, scales did not correctly calculate min/max for combo charts. See #1263 

## Old Behaviour
![old stacked](https://cloud.githubusercontent.com/assets/6757853/10869285/5fa978d0-8078-11e5-83b9-f71f73772302.png)

## New Behaviour
![new stacked](https://cloud.githubusercontent.com/assets/6757853/10869286/657515d0-8078-11e5-96cd-7cd1abe964e1.png)
