### PR TITLE
Fixes bar charts when only Y scale is in stacked mode

### DIFF
--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -293,7 +293,7 @@
 			var leftTick = xScale.getPixelForValue(null, index, barIndex, this.chart.isCombo);
 			leftTick -= this.chart.isCombo ? (ruler.tickWidth / 2) : 0;
 
-			if (yScale.options.stacked) {
+			if (xScale.options.stacked) {
 				return leftTick + (ruler.categoryWidth / 2) + ruler.categorySpacing;
 			}
 


### PR DESCRIPTION
## Old Behaviour
![waterfall bar](https://cloud.githubusercontent.com/assets/6757853/10872774/4bf489ce-80d7-11e5-91f4-443cdfe69832.png)

## New Behaviour
![waterfall](https://cloud.githubusercontent.com/assets/6757853/10872778/550e04b8-80d7-11e5-8e67-2047d279d733.png)
