### PR TITLE
Fix: no tooltips when missing data for one or more dataset

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -439,7 +439,8 @@
 					case 'label':
 					case 'dataset':
 						for (var i = 0; i < this.lastActive.length; i++) {
-							this.data.datasets[this.lastActive[i]._datasetIndex].controller.removeHoverStyle(this.lastActive[i], this.lastActive[i]._datasetIndex, this.lastActive[i]._index);
+                            if (this.lastActive[i])
+							    this.data.datasets[this.lastActive[i]._datasetIndex].controller.removeHoverStyle(this.lastActive[i], this.lastActive[i]._datasetIndex, this.lastActive[i]._index);
 						}
 						break;
 					default:
@@ -456,7 +457,8 @@
 					case 'label':
 					case 'dataset':
 						for (var j = 0; j < this.active.length; j++) {
-							this.data.datasets[this.active[j]._datasetIndex].controller.setHoverStyle(this.active[j]);
+                            if (this.active[j])
+							    this.data.datasets[this.active[j]._datasetIndex].controller.setHoverStyle(this.active[j]);
 						}
 						break;
 					default:

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -439,8 +439,8 @@
 					case 'label':
 					case 'dataset':
 						for (var i = 0; i < this.lastActive.length; i++) {
-                            if (this.lastActive[i])
-							    this.data.datasets[this.lastActive[i]._datasetIndex].controller.removeHoverStyle(this.lastActive[i], this.lastActive[i]._datasetIndex, this.lastActive[i]._index);
+							if (this.lastActive[i])
+						  		this.data.datasets[this.lastActive[i]._datasetIndex].controller.removeHoverStyle(this.lastActive[i], this.lastActive[i]._datasetIndex, this.lastActive[i]._index);
 						}
 						break;
 					default:
@@ -457,8 +457,8 @@
 					case 'label':
 					case 'dataset':
 						for (var j = 0; j < this.active.length; j++) {
-                            if (this.active[j])
-							    this.data.datasets[this.active[j]._datasetIndex].controller.setHoverStyle(this.active[j]);
+							if (this.active[j])
+				  				this.data.datasets[this.active[j]._datasetIndex].controller.setHoverStyle(this.active[j]);
 						}
 						break;
 					default:

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -203,9 +203,11 @@
 			var yPositions = [];
 
 			helpers.each(elements, function(el){
-				var pos = el.tooltipPosition();
-				xPositions.push(pos.x);
-				yPositions.push(pos.y);
+				if(el) {
+					var pos = el.tooltipPosition();
+					xPositions.push(pos.x);
+					yPositions.push(pos.y);
+				}
 			});
 
 			var x = 0, y = 0;
@@ -249,21 +251,25 @@
 							return;
 						}
 						var currentElement = dataset.metaData[element._index];
-						var yScale = element._yScale || element._scale; // handle radar || polarArea charts
+						if (currentElement) {
+							var yScale = element._yScale || element._scale; // handle radar || polarArea charts
 
-						tooltipItems.push({
-							xLabel: currentElement._xScale ? currentElement._xScale.getLabelForIndex(currentElement._index, currentElement._datasetIndex) : '',
-							yLabel: yScale ? yScale.getLabelForIndex(currentElement._index, currentElement._datasetIndex) : '',
-							index: element._index,
-							datasetIndex: datasetIndex,
-						});
+							tooltipItems.push({
+								xLabel: currentElement._xScale ? currentElement._xScale.getLabelForIndex(currentElement._index, currentElement._datasetIndex) : '',
+								yLabel: yScale ? yScale.getLabelForIndex(currentElement._index, currentElement._datasetIndex) : '',
+								index: element._index,
+								datasetIndex: datasetIndex,
+							});
+						}
 					});
 
 					helpers.each(this._active, function(active, i) {
-						labelColors.push({
-							borderColor: active._view.borderColor,
-							backgroundColor: active._view.backgroundColor
-						});
+						if (active) {
+						  labelColors.push({
+						  	borderColor: active._view.borderColor,
+						  	backgroundColor: active._view.backgroundColor
+						  });
+						}
 					}, this);
 
 					tooltipPosition = this.getAveragePosition(this._active);


### PR DESCRIPTION
Add some tests before pushing some data to tooltips. If some points are missing in one or more datasets, there is no more error during tooltips construction.