### PR TITLE
Do not bind to touchend events for tooltips

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -79,7 +79,7 @@
 			responsive: true,
 			responsiveAnimationDuration: 0,
 			maintainAspectRatio: true,
-			events: ["mousemove", "mouseout", "click", "touchstart", "touchmove", "touchend"],
+			events: ["mousemove", "mouseout", "click", "touchstart", "touchmove"],
 			hover: {
 				onHover: null,
 				mode: 'single',


### PR DESCRIPTION
Fixes #1587
`touchend` events generally do not have associated touches (since there are usually no more touch points). V1.x did not bind to this event and v2.0 should not either.