### PR TITLE
Can now replace entire chart data object on the fly

### DIFF
--- a/samples/line.html
+++ b/samples/line.html
@@ -19,6 +19,7 @@
     <br>
     <br>
     <button id="randomizeData">Randomize Data</button>
+    <button id="changeDataObject">Change Data Object</button>
     <button id="addDataset">Add Dataset</button>
     <button id="removeDataset">Remove Dataset</button>
     <button id="addData">Add Data</button>
@@ -145,6 +146,32 @@
 
             window.myLine.update();
             updateLegend();
+        });
+
+        $('#changeDataObject').click(function() {
+            config.data = {
+                labels: ["July", "August", "September", "October", "November", "December"],
+                datasets: [{
+                    label: "My First dataset",
+                    data: [randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor()],
+                    fill: false,
+                }, {
+                    label: "My Second dataset",
+                    fill: false,
+                    data: [randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor(), randomScalingFactor()],
+                }]
+            };
+
+            $.each(config.data.datasets, function(i, dataset) {
+                dataset.borderColor = randomColor(0.4);
+                dataset.backgroundColor = randomColor(0.5);
+                dataset.pointBorderColor = randomColor(0.7);
+                dataset.pointBackgroundColor = randomColor(0.5);
+                dataset.pointBorderWidth = 1;
+            });
+
+            // Update the chart
+            window.myLine.update();
         });
 
         $('#addDataset').click(function() {

--- a/src/scales/scale.category.js
+++ b/src/scales/scale.category.js
@@ -12,7 +12,7 @@
 
     var DatasetScale = Chart.Scale.extend({
         buildTicks: function(index) {
-            this.ticks = this.data.labels;
+            this.ticks = this.chart.data.labels;
         },
 
         getLabelForIndex: function(index, datasetIndex) {
@@ -23,7 +23,7 @@
         getPixelForValue: function(value, index, datasetIndex, includeOffset) {
             if (this.isHorizontal()) {
                 var innerWidth = this.width - (this.paddingLeft + this.paddingRight);
-                var valueWidth = innerWidth / Math.max((this.data.labels.length - ((this.options.gridLines.offsetGridLines) ? 0 : 1)), 1);
+                var valueWidth = innerWidth / Math.max((this.chart.data.labels.length - ((this.options.gridLines.offsetGridLines) ? 0 : 1)), 1);
                 var widthOffset = (valueWidth * index) + this.paddingLeft;
 
                 if (this.options.gridLines.offsetGridLines && includeOffset) {
@@ -33,7 +33,7 @@
                 return this.left + Math.round(widthOffset);
             } else {
                 var innerHeight = this.height - (this.paddingTop + this.paddingBottom);
-                var valueHeight = innerHeight / Math.max((this.data.labels.length - ((this.options.gridLines.offsetGridLines) ? 0 : 1)), 1);
+                var valueHeight = innerHeight / Math.max((this.chart.data.labels.length - ((this.options.gridLines.offsetGridLines) ? 0 : 1)), 1);
                 var heightOffset = (valueHeight * index) + this.paddingTop;
 
                 if (this.options.gridLines.offsetGridLines && includeOffset) {

--- a/src/scales/scale.linear.js
+++ b/src/scales/scale.linear.js
@@ -45,7 +45,7 @@
 			if (this.options.stacked) {
 				var valuesPerType = {};
 
-				helpers.each(this.data.datasets, function(dataset) {
+				helpers.each(this.chart.data.datasets, function(dataset) {
 					if (valuesPerType[dataset.type] === undefined) {
 						valuesPerType[dataset.type] = {
 							positiveValues: [],
@@ -90,7 +90,7 @@
 				}, this);
 
 			} else {
-				helpers.each(this.data.datasets, function(dataset) {
+				helpers.each(this.chart.data.datasets, function(dataset) {
 					if (helpers.isDatasetVisible(dataset) && (this.isHorizontal() ? dataset.xAxisID === this.id : dataset.yAxisID === this.id)) {
 						helpers.each(dataset.data, function(rawValue, index) {
 							var value = this.getRightValue(rawValue);
@@ -205,7 +205,7 @@
 		},
 
 		getLabelForIndex: function(index, datasetIndex) {
-			return this.getRightValue(this.data.datasets[datasetIndex].data[index]);
+			return this.getRightValue(this.chart.data.datasets[datasetIndex].data[index]);
 		},
 
 		// Utils

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -33,7 +33,7 @@
 			if (this.options.stacked) {
 				var valuesPerType = {};
 
-				helpers.each(this.data.datasets, function(dataset) {
+				helpers.each(this.chart.data.datasets, function(dataset) {
 					if (helpers.isDatasetVisible(dataset) && (this.isHorizontal() ? dataset.xAxisID === this.id : dataset.yAxisID === this.id)) {
 						if (valuesPerType[dataset.type] === undefined) {
 							valuesPerType[dataset.type] = [];
@@ -66,7 +66,7 @@
 				}, this);
 
 			} else {
-				helpers.each(this.data.datasets, function(dataset) {
+				helpers.each(this.chart.data.datasets, function(dataset) {
 					if (helpers.isDatasetVisible(dataset) && (this.isHorizontal() ? dataset.xAxisID === this.id : dataset.yAxisID === this.id)) {
 						helpers.each(dataset.data, function(rawValue, index) {
 							var value = this.getRightValue(rawValue);
@@ -145,7 +145,7 @@
 		},
 		// Get the correct tooltip label
 		getLabelForIndex: function(index, datasetIndex) {
-			return this.getRightValue(this.data.datasets[datasetIndex].data[index]);
+			return this.getRightValue(this.chart.data.datasets[datasetIndex].data[index]);
 		},
 		getPixelForTick: function(index, includeOffset) {
 			return this.getPixelForValue(this.tickValues[index], null, null, includeOffset);

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -51,7 +51,7 @@
 
 	var LinearRadialScale = Chart.Scale.extend({
 		getValueCount: function() {
-			return this.data.labels.length;
+			return this.chart.data.labels.length;
 		},
 		setDimensions: function() {
 			// Set the unconstrained dimension before label rotation
@@ -67,7 +67,7 @@
 			this.min = null;
 			this.max = null;
 
-			helpers.each(this.data.datasets, function(dataset) {
+			helpers.each(this.chart.data.datasets, function(dataset) {
 				if (helpers.isDatasetVisible(dataset)) {
 					helpers.each(dataset.data, function(rawValue, index) {
 						var value = this.getRightValue(rawValue);
@@ -153,7 +153,7 @@
 			this.zeroLineIndex = this.ticks.indexOf(0);
 		},
 		getLabelForIndex: function(index, datasetIndex) {
-			return this.getRightValue(this.data.datasets[datasetIndex].data[index]);
+			return this.getRightValue(this.chart.data.datasets[datasetIndex].data[index]);
 		},
 		getCircumference: function() {
 			return ((Math.PI * 2) / this.getValueCount());
@@ -210,7 +210,7 @@
 			for (i = 0; i < this.getValueCount(); i++) {
 				// 5px to space the text slightly out - similar to what we do in the draw function.
 				pointPosition = this.getPointPosition(i, largestPossibleRadius);
-				textWidth = this.ctx.measureText(this.options.ticks.callback(this.data.labels[i])).width + 5;
+				textWidth = this.ctx.measureText(this.options.ticks.callback(this.chart.data.labels[i])).width + 5;
 				if (i === 0 || i === this.getValueCount() / 2) {
 					// If we're at index zero, or exactly the middle, we're at exactly the top/bottom
 					// of the radar chart, so text will be aligned centrally, so we'll half it and compare
@@ -367,8 +367,8 @@
 						ctx.font = helpers.fontString(this.options.pointLabels.fontSize, this.options.pointLabels.fontStyle, this.options.pointLabels.fontFamily);
 						ctx.fillStyle = this.options.pointLabels.fontColor;
 
-						var labelsCount = this.data.labels.length,
-							halfLabelsCount = this.data.labels.length / 2,
+						var labelsCount = this.chart.data.labels.length,
+							halfLabelsCount = this.chart.data.labels.length / 2,
 							quarterLabelsCount = halfLabelsCount / 2,
 							upperHalf = (i < quarterLabelsCount || i > labelsCount - quarterLabelsCount),
 							exactQuarter = (i === quarterLabelsCount || i === labelsCount - quarterLabelsCount);
@@ -391,7 +391,7 @@
 							ctx.textBaseline = 'top';
 						}
 
-						ctx.fillText(this.data.labels[i], pointLabelPosition.x, pointLabelPosition.y);
+						ctx.fillText(this.chart.data.labels[i], pointLabelPosition.x, pointLabelPosition.y);
 					}
 				}
 			}

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -82,8 +82,8 @@
 			// Only parse these once. If the dataset does not have data as x,y pairs, we will use
 			// these 
 			var scaleLabelMoments = [];
-			if (this.data.labels && this.data.labels.length > 0) {
-				helpers.each(this.data.labels, function(label, index) {
+			if (this.chart.data.labels && this.chart.data.labels.length > 0) {
+				helpers.each(this.chart.data.labels, function(label, index) {
 					var labelMoment = this.parseTime(label);
 					if (this.options.time.round) {
 						labelMoment.startOf(this.options.time.round);
@@ -107,7 +107,7 @@
 				this.lastTick = null;
 			}
 
-			helpers.each(this.data.datasets, function(dataset, datasetIndex) {
+			helpers.each(this.chart.data.datasets, function(dataset, datasetIndex) {
 				var momentsForDataset = [];
 
 				if (typeof dataset.data[0] === 'object') {
@@ -174,7 +174,7 @@
 			this.lastTick.endOf(this.tickUnit);
 			this.smallestLabelSeparation = this.width;
 
-			helpers.each(this.data.datasets, function(dataset, datasetIndex) {
+			helpers.each(this.chart.data.datasets, function(dataset, datasetIndex) {
 				for (var i = 1; i < this.labelMoments[datasetIndex].length; i++) {
 					this.smallestLabelSeparation = Math.min(this.smallestLabelSeparation, this.labelMoments[datasetIndex][i].diff(this.labelMoments[datasetIndex][i - 1], this.tickUnit, true));
 				}
@@ -192,10 +192,10 @@
 		},
 		// Get tooltip label
 		getLabelForIndex: function(index, datasetIndex) {
-			var label = this.data.labels && index < this.data.labels.length ? this.data.labels[index] : '';
+			var label = this.chart.data.labels && index < this.chart.data.labels.length ? this.chart.data.labels[index] : '';
 
-			if (typeof this.data.datasets[datasetIndex].data[0] === 'object') {
-				label = this.getRightValue(this.data.datasets[datasetIndex].data[index]);
+			if (typeof this.chart.data.datasets[datasetIndex].data[0] === 'object') {
+				label = this.getRightValue(this.chart.data.datasets[datasetIndex].data[index]);
 			}
 
 			return label;

--- a/test/controller.bar.tests.js
+++ b/test/controller.bar.tests.js
@@ -190,7 +190,9 @@ describe('Bar controller tests', function() {
 		var yScale = new VerticalScaleConstructor({
 			ctx: mockContext,
 			options: verticalScaleConfig,
-			data: data,
+			chart: {
+				data: data
+			},
 			id: 'firstYScaleID'
 		});
 
@@ -207,7 +209,9 @@ describe('Bar controller tests', function() {
 		var xScale = new HorizontalScaleConstructor({
 			ctx: mockContext,
 			options: horizontalScaleConfig,
-			data: data,
+			chart: {
+				data: data
+			},
 			id: 'firstXScaleID'
 		});
 
@@ -316,7 +320,9 @@ describe('Bar controller tests', function() {
 		var yScale = new VerticalScaleConstructor({
 			ctx: mockContext,
 			options: verticalScaleConfig,
-			data: data,
+			chart: {
+				data: data
+			},
 			id: 'firstYScaleID'
 		});
 
@@ -333,7 +339,9 @@ describe('Bar controller tests', function() {
 		var xScale = new HorizontalScaleConstructor({
 			ctx: mockContext,
 			options: horizontalScaleConfig,
-			data: data,
+			chart: {
+				data: data
+			},
 			id: 'firstXScaleID'
 		});
 
@@ -399,7 +407,9 @@ describe('Bar controller tests', function() {
 		var yScale = new VerticalScaleConstructor({
 			ctx: mockContext,
 			options: verticalScaleConfig,
-			data: data,
+			chart: {
+				data: data
+			},
 			id: 'firstYScaleID'
 		});
 
@@ -416,7 +426,9 @@ describe('Bar controller tests', function() {
 		var xScale = new HorizontalScaleConstructor({
 			ctx: mockContext,
 			options: horizontalScaleConfig,
-			data: data,
+			chart: {
+				data: data
+			},
 			id: 'firstXScaleID'
 		});
 
@@ -519,7 +531,9 @@ describe('Bar controller tests', function() {
 		var yScale = new VerticalScaleConstructor({
 			ctx: mockContext,
 			options: verticalScaleConfig,
-			data: data,
+			chart: {
+				data: data
+			},
 			id: 'firstYScaleID'
 		});
 
@@ -536,7 +550,9 @@ describe('Bar controller tests', function() {
 		var xScale = new HorizontalScaleConstructor({
 			ctx: mockContext,
 			options: horizontalScaleConfig,
-			data: data,
+			chart: {
+				data: data
+			},
 			id: 'firstXScaleID'
 		});
 

--- a/test/controller.line.tests.js
+++ b/test/controller.line.tests.js
@@ -159,7 +159,9 @@ describe('Line controller tests', function() {
 		var yScale = new VerticalScaleConstructor({
 			ctx: mockContext,
 			options: verticalScaleConfig,
-			data: data,
+			chart: {
+				data: data
+			},
 			id: 'firstYScaleID'
 		});
 
@@ -176,7 +178,9 @@ describe('Line controller tests', function() {
 		var xScale = new HorizontalScaleConstructor({
 			ctx: mockContext,
 			options: horizontalScaleConfig,
-			data: data,
+			chart: {
+				data: data
+			},
 			id: 'firstXScaleID'
 		});
 
@@ -534,7 +538,9 @@ describe('Line controller tests', function() {
 		var yScale = new VerticalScaleConstructor({
 			ctx: mockContext,
 			options: verticalScaleConfig,
-			data: data,
+			chart: {
+				data: data
+			},
 			id: 'firstYScaleID'
 		});
 
@@ -551,7 +557,9 @@ describe('Line controller tests', function() {
 		var xScale = new HorizontalScaleConstructor({
 			ctx: mockContext,
 			options: horizontalScaleConfig,
-			data: data,
+			chart: {
+				data: data
+			},
 			id: 'firstXScaleID'
 		});
 
@@ -649,7 +657,9 @@ describe('Line controller tests', function() {
 		var yScale = new VerticalScaleConstructor({
 			ctx: mockContext,
 			options: verticalScaleConfig,
-			data: data,
+			chart: {
+				data: data
+			},
 			id: 'firstYScaleID'
 		});
 
@@ -666,7 +676,9 @@ describe('Line controller tests', function() {
 		var xScale = new HorizontalScaleConstructor({
 			ctx: mockContext,
 			options: horizontalScaleConfig,
-			data: data,
+			chart: {
+				data: data
+			},
 			id: 'firstXScaleID'
 		});
 
@@ -783,7 +795,9 @@ describe('Line controller tests', function() {
 		var yScale = new VerticalScaleConstructor({
 			ctx: mockContext,
 			options: verticalScaleConfig,
-			data: data,
+			chart: {
+				data: data
+			},
 			id: 'firstYScaleID'
 		});
 
@@ -800,7 +814,9 @@ describe('Line controller tests', function() {
 		var xScale = new HorizontalScaleConstructor({
 			ctx: mockContext,
 			options: horizontalScaleConfig,
-			data: data,
+			chart: {
+				data: data
+			},
 			id: 'firstXScaleID'
 		});
 

--- a/test/core.scaleService.tests.js
+++ b/test/core.scaleService.tests.js
@@ -21,7 +21,9 @@ describe('Test the scale service', function() {
 		var xScale = new XConstructor({
 			ctx: mockContext,
 			options: xScaleConfig,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: xScaleID
 		});
 
@@ -30,7 +32,9 @@ describe('Test the scale service', function() {
 		var yScale = new YConstructor({
 			ctx: mockContext,
 			options: yScaleConfig,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: yScaleID
 		});
 
@@ -84,7 +88,9 @@ describe('Test the scale service', function() {
 		var xScale = new XConstructor({
 			ctx: mockContext,
 			options: xScaleConfig,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: xScaleID
 		});
 
@@ -94,7 +100,9 @@ describe('Test the scale service', function() {
 		var yScale = new YConstructor({
 			ctx: mockContext,
 			options: yScaleConfig,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: yScaleID
 		});
 
@@ -151,7 +159,9 @@ describe('Test the scale service', function() {
 		var xScale = new XConstructor({
 			ctx: mockContext,
 			options: xScaleConfig,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: xScaleID
 		});
 
@@ -160,13 +170,17 @@ describe('Test the scale service', function() {
 		var yScale1 = new YConstructor({
 			ctx: mockContext,
 			options: yScaleConfig,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: yScaleID1
 		});
 		var yScale2 = new YConstructor({
 			ctx: mockContext,
 			options: yScaleConfig,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: yScaleID2
 		});
 
@@ -230,7 +244,9 @@ describe('Test the scale service', function() {
 		var scale = new ScaleConstructor({
 			ctx: mockContext,
 			options: scaleConfig,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 

--- a/test/scale.category.tests.js
+++ b/test/scale.category.tests.js
@@ -67,7 +67,9 @@ describe('Category scale tests', function() {
 		var scale = new Constructor({
 			ctx: {},
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -93,7 +95,9 @@ describe('Category scale tests', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -151,7 +155,9 @@ describe('Category scale tests', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 

--- a/test/scale.linear.tests.js
+++ b/test/scale.linear.tests.js
@@ -69,7 +69,9 @@ describe('Linear Scale', function() {
 		var scale = new Constructor({
 			ctx: {},
 			options: Chart.scaleService.getScaleDefaults('linear'), // use default config for scale
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -107,7 +109,9 @@ describe('Linear Scale', function() {
 		var scale = new Constructor({
 			ctx: {},
 			options: Chart.scaleService.getScaleDefaults('linear'), // use default config for scale
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -152,7 +156,9 @@ describe('Linear Scale', function() {
 		var verticalScale = new Constructor({
 			ctx: {},
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -169,7 +175,9 @@ describe('Linear Scale', function() {
 		var horizontalScale = new Constructor({
 			ctx: {},
 			options: horizontalConfig,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID,
 		});
 
@@ -211,7 +219,9 @@ describe('Linear Scale', function() {
 		var scale = new Constructor({
 			ctx: {},
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -251,7 +261,9 @@ describe('Linear Scale', function() {
 		var scale = new Constructor({
 			ctx: {},
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -276,7 +288,9 @@ describe('Linear Scale', function() {
 		var scale = new Constructor({
 			ctx: {},
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -307,7 +321,9 @@ describe('Linear Scale', function() {
 		var scale = new Constructor({
 			ctx: {},
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -337,7 +353,9 @@ describe('Linear Scale', function() {
 		var scale = new Constructor({
 			ctx: {},
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -376,7 +394,9 @@ describe('Linear Scale', function() {
 		var scale = new Constructor({
 			ctx: {},
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -408,7 +428,9 @@ describe('Linear Scale', function() {
 		var scale = new Constructor({
 			ctx: {},
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -440,7 +462,9 @@ describe('Linear Scale', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -465,7 +489,9 @@ describe('Linear Scale', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -494,7 +520,9 @@ describe('Linear Scale', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -521,7 +549,9 @@ describe('Linear Scale', function() {
 		var verticalScale = new Constructor({
 			ctx: mockContext,
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -547,7 +577,9 @@ describe('Linear Scale', function() {
 		var horizontalScale = new Constructor({
 			ctx: mockContext,
 			options: horizontalConfig,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID,
 		});
 
@@ -586,7 +618,9 @@ describe('Linear Scale', function() {
 		var verticalScale = new Constructor({
 			ctx: mockContext,
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -645,7 +679,9 @@ describe('Linear Scale', function() {
 		var horizontalScale = new Constructor({
 			ctx: mockContext,
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -705,7 +741,9 @@ describe('Linear Scale', function() {
 		var horizontalScale = new Constructor({
 			ctx: mockContext,
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -936,7 +974,9 @@ describe('Linear Scale', function() {
 		var verticalScale = new Constructor({
 			ctx: mockContext,
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 

--- a/test/scale.logarithmic.tests.js
+++ b/test/scale.logarithmic.tests.js
@@ -70,7 +70,9 @@ describe('Logarithmic Scale tests', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: Chart.scaleService.getScaleDefaults('logarithmic'), // use default config for scale
-			data: mockData,
+			chart: {
+				data: mockData,
+			},
 			id: scaleID
 		});
 
@@ -105,7 +107,9 @@ describe('Logarithmic Scale tests', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: Chart.scaleService.getScaleDefaults('logarithmic'), // use default config for scale
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -147,7 +151,9 @@ describe('Logarithmic Scale tests', function() {
 		var verticalScale = new Constructor({
 			ctx: mockContext,
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -160,7 +166,9 @@ describe('Logarithmic Scale tests', function() {
 		var horizontalScale = new Constructor({
 			ctx: mockContext,
 			options: horizontalConfig,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID,
 		});
 
@@ -199,7 +207,9 @@ describe('Logarithmic Scale tests', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -240,7 +250,9 @@ describe('Logarithmic Scale tests', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -262,7 +274,9 @@ describe('Logarithmic Scale tests', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -295,7 +309,9 @@ describe('Logarithmic Scale tests', function() {
 		var scale = new Constructor({
 			ctx: {},
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -328,7 +344,9 @@ describe('Logarithmic Scale tests', function() {
 		var scale = new Constructor({
 			ctx: {},
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -360,7 +378,9 @@ describe('Logarithmic Scale tests', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -389,7 +409,9 @@ describe('Logarithmic Scale tests', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -416,7 +438,9 @@ describe('Logarithmic Scale tests', function() {
 		var verticalScale = new Constructor({
 			ctx: mockContext,
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -441,7 +465,9 @@ describe('Logarithmic Scale tests', function() {
 		var horizontalScale = new Constructor({
 			ctx: mockContext,
 			options: horizontalConfig,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID,
 		});
 

--- a/test/scale.radialLinear.tests.js
+++ b/test/scale.radialLinear.tests.js
@@ -86,7 +86,9 @@ describe('Test the radial linear scale', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: Chart.scaleService.getScaleDefaults('radialLinear'), // use default config for scale
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID,
 		});
 
@@ -118,7 +120,9 @@ describe('Test the radial linear scale', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: Chart.scaleService.getScaleDefaults('radialLinear'), // use default config for scale
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID,
 		});
 
@@ -140,7 +144,9 @@ describe('Test the radial linear scale', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: Chart.scaleService.getScaleDefaults('radialLinear'), // use default config for scale
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID,
 		});
 
@@ -166,7 +172,9 @@ describe('Test the radial linear scale', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID,
 		});
 
@@ -205,7 +213,9 @@ describe('Test the radial linear scale', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID,
 		});
 
@@ -238,7 +248,9 @@ describe('Test the radial linear scale', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID,
 		});
 
@@ -265,7 +277,9 @@ describe('Test the radial linear scale', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID,
 		});
 
@@ -297,7 +311,9 @@ describe('Test the radial linear scale', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID,
 		});
 
@@ -340,7 +356,9 @@ describe('Test the radial linear scale', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID,
 		});
 

--- a/test/scale.time.tests.js
+++ b/test/scale.time.tests.js
@@ -72,7 +72,9 @@ describe('Time scale tests', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: Chart.scaleService.getScaleDefaults('time'), // use default config for scale
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -97,7 +99,9 @@ describe('Time scale tests', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: config, // use default config for scale
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -121,7 +125,9 @@ describe('Time scale tests', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: config, // use default config for scale
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -145,7 +151,9 @@ describe('Time scale tests', function() {
 		var scale = new Constructor({
 			ctx: mockContext,
 			options: Chart.scaleService.getScaleDefaults('time'), // use default config for scale
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 
@@ -168,7 +176,9 @@ describe('Time scale tests', function() {
 		var verticalScale = new Constructor({
 			ctx: mockContext,
 			options: verticalScaleConfig,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 		verticalScale.update(50, 400);


### PR DESCRIPTION
Fixes #1640
You can now change the entire data object of the chart and then call update and the chart will work. The line sample has been update to test this behaviour. 

Note to whomever reviews this: please test all chart types before merging.