### PR TITLE
Tooltip visibility

### DIFF
--- a/Chart.js
+++ b/Chart.js
@@ -1638,7 +1638,6 @@
 			if (this.options.tooltips.enabled || this.options.tooltips.custom) {
 
 				// The usual updates
-				this.tooltip.initialize();
 				this.tooltip._active = this.tooltipActive;
 			}
 


### PR DESCRIPTION
Multiple calls to the tooltip initialize method has caused the tooltip to disappear.