### PR TITLE
Handle data as strings in numeric scales

### DIFF
--- a/src/scales/scale.linear.js
+++ b/src/scales/scale.linear.js
@@ -60,7 +60,7 @@
 					if (helpers.isDatasetVisible(dataset) && (this.isHorizontal() ? dataset.xAxisID === this.id : dataset.yAxisID === this.id)) {
 						helpers.each(dataset.data, function(rawValue, index) {
 
-							var value = this.getRightValue(rawValue);
+							var value = +this.getRightValue(rawValue);
 							if (isNaN(value)) {
 								return;
 							}
@@ -93,7 +93,7 @@
 				helpers.each(this.chart.data.datasets, function(dataset) {
 					if (helpers.isDatasetVisible(dataset) && (this.isHorizontal() ? dataset.xAxisID === this.id : dataset.yAxisID === this.id)) {
 						helpers.each(dataset.data, function(rawValue, index) {
-							var value = this.getRightValue(rawValue);
+							var value = +this.getRightValue(rawValue);
 							if (isNaN(value)) {
 								return;
 							}
@@ -205,14 +205,14 @@
 		},
 
 		getLabelForIndex: function(index, datasetIndex) {
-			return this.getRightValue(this.chart.data.datasets[datasetIndex].data[index]);
+			return +this.getRightValue(this.chart.data.datasets[datasetIndex].data[index]);
 		},
 
 		// Utils
 		getPixelForValue: function(value, index, datasetIndex, includeOffset) {
 			// This must be called after fit has been run so that 
 			//      this.left, this.top, this.right, and this.bottom have been defined
-			var rightValue = this.getRightValue(value);
+			var rightValue = +this.getRightValue(value);
 			var pixel;
 			var range = this.end - this.start;
 

--- a/src/scales/scale.logarithmic.js
+++ b/src/scales/scale.logarithmic.js
@@ -41,7 +41,7 @@
 
 						helpers.each(dataset.data, function(rawValue, index) {
 							var values = valuesPerType[dataset.type];
-							var value = this.getRightValue(rawValue);
+							var value = +this.getRightValue(rawValue);
 							if (isNaN(value)) {
 								return;
 							}
@@ -69,7 +69,7 @@
 				helpers.each(this.chart.data.datasets, function(dataset) {
 					if (helpers.isDatasetVisible(dataset) && (this.isHorizontal() ? dataset.xAxisID === this.id : dataset.yAxisID === this.id)) {
 						helpers.each(dataset.data, function(rawValue, index) {
-							var value = this.getRightValue(rawValue);
+							var value = +this.getRightValue(rawValue);
 							if (isNaN(value)) {
 								return;
 							}
@@ -145,7 +145,7 @@
 		},
 		// Get the correct tooltip label
 		getLabelForIndex: function(index, datasetIndex) {
-			return this.getRightValue(this.chart.data.datasets[datasetIndex].data[index]);
+			return +this.getRightValue(this.chart.data.datasets[datasetIndex].data[index]);
 		},
 		getPixelForTick: function(index, includeOffset) {
 			return this.getPixelForValue(this.tickValues[index], null, null, includeOffset);
@@ -153,7 +153,7 @@
 		getPixelForValue: function(value, index, datasetIndex, includeOffset) {
 			var pixel;
 
-			var newVal = this.getRightValue(value);
+			var newVal = +this.getRightValue(value);
 			var range = helpers.log10(this.end) - helpers.log10(this.start);
 
 			if (this.isHorizontal()) {

--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -70,7 +70,7 @@
 			helpers.each(this.chart.data.datasets, function(dataset) {
 				if (helpers.isDatasetVisible(dataset)) {
 					helpers.each(dataset.data, function(rawValue, index) {
-						var value = this.getRightValue(rawValue);
+						var value = +this.getRightValue(rawValue);
 						if (isNaN(value)) {
 							return;
 						}
@@ -153,7 +153,7 @@
 			this.zeroLineIndex = this.ticks.indexOf(0);
 		},
 		getLabelForIndex: function(index, datasetIndex) {
-			return this.getRightValue(this.chart.data.datasets[datasetIndex].data[index]);
+			return +this.getRightValue(this.chart.data.datasets[datasetIndex].data[index]);
 		},
 		getCircumference: function() {
 			return ((Math.PI * 2) / this.getValueCount());

--- a/test/controller.line.tests.js
+++ b/test/controller.line.tests.js
@@ -543,7 +543,9 @@ describe('Line controller tests', function() {
 		var yScale = new VerticalScaleConstructor({
 			ctx: mockContext,
 			options: verticalScaleConfig,
-			data: data,
+			chart: {
+				data: data
+			},
 			id: 'firstYScaleID'
 		});
 
@@ -560,7 +562,9 @@ describe('Line controller tests', function() {
 		var xScale = new HorizontalScaleConstructor({
 			ctx: mockContext,
 			options: horizontalScaleConfig,
-			data: data,
+			chart: {
+				data: data
+			},
 			id: 'firstXScaleID'
 		});
 

--- a/test/scale.linear.tests.js
+++ b/test/scale.linear.tests.js
@@ -1530,7 +1530,9 @@ describe('Linear Scale', function() {
 		var verticalScale = new Constructor({
 			ctx: mockContext,
 			options: config,
-			data: mockData,
+			chart: {
+				data: mockData
+			},
 			id: scaleID
 		});
 

--- a/test/scale.linear.tests.js
+++ b/test/scale.linear.tests.js
@@ -88,6 +88,45 @@ describe('Linear Scale', function() {
 		expect(scale.max).toBe(150);
 	});
 
+	it('Should correctly determine the max & min of string data values', function() {
+		var scaleID = 'myScale';
+
+		var mockData = {
+			datasets: [{
+				yAxisID: scaleID,
+				data: ['10', '5', '0', '-5', '78', '-100']
+			}, {
+				yAxisID: 'second scale',
+				data: ['-1000', '1000'],
+			}, {
+				yAxisID: scaleID,
+				data: ['150']
+			}]
+		};
+
+		var Constructor = Chart.scaleService.getScaleConstructor('linear');
+		var scale = new Constructor({
+			ctx: {},
+			options: Chart.scaleService.getScaleDefaults('linear'), // use default config for scale
+			chart: {
+				data: mockData
+			},
+			id: scaleID
+		});
+
+		expect(scale).not.toEqual(undefined); // must construct
+		expect(scale.min).toBe(undefined); // not yet set
+		expect(scale.max).toBe(undefined);
+
+		// Set arbitrary width and height for now
+		scale.width = 50;
+		scale.height = 400;
+
+		scale.buildTicks();
+		expect(scale.min).toBe(-100);
+		expect(scale.max).toBe(150);
+	});
+
 	it('Should correctly determine the max & min data values ignoring hidden datasets', function() {
 		var scaleID = 'myScale';
 

--- a/test/scale.logarithmic.tests.js
+++ b/test/scale.logarithmic.tests.js
@@ -85,6 +85,42 @@ describe('Logarithmic Scale tests', function() {
 		expect(scale.max).toBe(10000);
 	});
 
+	it('Should correctly determine the max & min of string data values', function() {
+		var scaleID = 'myScale';
+
+		var mockData = {
+			datasets: [{
+				yAxisID: scaleID,
+				data: ['10', '5', '5000', '78', '450']
+			}, {
+				yAxisID: 'second scale',
+				data: ['1', '1000', '10', '100'],
+			}, {
+				yAxisID: scaleID,
+				data: ['150']
+			}]
+		};
+
+		var mockContext = window.createMockContext();
+		var Constructor = Chart.scaleService.getScaleConstructor('logarithmic');
+		var scale = new Constructor({
+			ctx: mockContext,
+			options: Chart.scaleService.getScaleDefaults('logarithmic'), // use default config for scale
+			chart: {
+				data: mockData,
+			},
+			id: scaleID
+		});
+
+		expect(scale).not.toEqual(undefined); // must construct
+		expect(scale.min).toBe(undefined); // not yet set
+		expect(scale.max).toBe(undefined);
+
+		scale.update(400, 400);
+		expect(scale.min).toBe(1);
+		expect(scale.max).toBe(10000);
+	});
+
 	it('Should correctly determine the max & min data values when there are hidden datasets', function() {
 		var scaleID = 'myScale';
 

--- a/test/scale.radialLinear.tests.js
+++ b/test/scale.radialLinear.tests.js
@@ -97,6 +97,36 @@ describe('Test the radial linear scale', function() {
 		expect(scale.max).toBe(200);
 	});
 
+	it('Should correctly determine the max & min of string data values', function() {
+		var scaleID = 'myScale';
+
+		var mockData = {
+			datasets: [{
+				yAxisID: scaleID,
+				data: ['10', '5', '0', '-5', '78', '-100']
+			}, {
+				yAxisID: scaleID,
+				data: ['150']
+			}],
+			labels: ['lablel1', 'label2', 'label3', 'label4', 'label5', 'label6']
+		};
+
+		var mockContext = window.createMockContext();
+		var Constructor = Chart.scaleService.getScaleConstructor('radialLinear');
+		var scale = new Constructor({
+			ctx: mockContext,
+			options: Chart.scaleService.getScaleDefaults('radialLinear'), // use default config for scale
+			chart: {
+				data: mockData
+			},
+			id: scaleID,
+		});
+
+		scale.update(200, 300);
+		expect(scale.min).toBe(-100);
+		expect(scale.max).toBe(200);
+	});
+
 	it('Should correctly determine the max & min data values when there are hidden datasets', function() {
 		var scaleID = 'myScale';
 


### PR DESCRIPTION
Fixes #1661 

Convert strings to numbers in scales so that min and max are correct. Updated tests to cover this case.