### PR TITLE
Fixes scatter and bubble chart tooltips

### DIFF
--- a/src/charts/Chart.Bubble.js
+++ b/src/charts/Chart.Bubble.js
@@ -41,7 +41,6 @@
 	Chart.defaults.bubble = defaultConfig;
 
 	Chart.Bubble = function(context, config) {
-		//config.options = helpers.configMerge(defaultConfig, config.options);
 		config.type = 'bubble';
 		return new Chart(context, config);
 	};

--- a/src/charts/Chart.Bubble.js
+++ b/src/charts/Chart.Bubble.js
@@ -24,14 +24,24 @@
 		},
 
 		tooltips: {
-			template: "(<%= value.x %>, <%= value.y %>)",
-			multiTemplate: "<%if (datasetLabel){%><%=datasetLabel%>: <%}%>(<%= value.x %>, <%= value.y %>)",
+			callbacks: {
+				title: function(tooltipItems, data) {
+					// Title doesn't make sense for scatter since we format the data as a point
+					return '';
+				},
+				label: function(tooltipItem, data) {
+					return '(' + tooltipItem.xLabel + ', ' + tooltipItem.yLabel + ')';
+				}
+			}
 		},
 
 	};
 
+	// Register the default config for this type
+	Chart.defaults.bubble = defaultConfig;
+
 	Chart.Bubble = function(context, config) {
-		config.options = helpers.configMerge(defaultConfig, config.options);
+		//config.options = helpers.configMerge(defaultConfig, config.options);
 		config.type = 'bubble';
 		return new Chart(context, config);
 	};

--- a/src/charts/Chart.Scatter.js
+++ b/src/charts/Chart.Scatter.js
@@ -43,7 +43,6 @@
 	Chart.controllers.scatter = Chart.controllers.line;
 
 	Chart.Scatter = function(context, config) {
-		//config.options = helpers.configMerge(defaultConfig, config.options);
 		config.type = 'scatter';
 		return new Chart(context, config);
 	};

--- a/src/charts/Chart.Scatter.js
+++ b/src/charts/Chart.Scatter.js
@@ -24,15 +24,27 @@
 		},
 
 		tooltips: {
-			template: "(<%= value.x %>, <%= value.y %>)",
-			multiTemplate: "<%if (datasetLabel){%><%=datasetLabel%>: <%}%>(<%= value.x %>, <%= value.y %>)",
+			callbacks: {
+				title: function(tooltipItems, data) {
+					// Title doesn't make sense for scatter since we format the data as a point
+					return '';
+				},
+				label: function(tooltipItem, data) {
+					return '(' + tooltipItem.xLabel + ', ' + tooltipItem.yLabel + ')';
+				}
+			}
 		},
-
 	};
 
+	// Register the default config for this type
+	Chart.defaults.scatter = defaultConfig;
+
+	// Scatter charts use line controllers
+	Chart.controllers.scatter = Chart.controllers.line;
+
 	Chart.Scatter = function(context, config) {
-		config.options = helpers.configMerge(defaultConfig, config.options);
-		config.type = 'line';
+		//config.options = helpers.configMerge(defaultConfig, config.options);
+		config.type = 'scatter';
 		return new Chart(context, config);
 	};
 	


### PR DESCRIPTION
This fixes tooltips for scatter and bubble charts. Also made the scatter chart a first class chart type so that you can create one (with the correct default) by doing

```javascript
var myChart = new Chart(ctx, {
    type: 'scatter',
    data: [],
    options: {}
});
```