### PR TITLE
Updated retina scale to allow rendering in IE10 and IE9.

### DIFF
--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -741,12 +741,12 @@
 			var ctx = chart.ctx;
 			var width = chart.canvas.width;
 			var height = chart.canvas.height;
-			chart.currentDevicePixelRatio = window.devicePixelRatio || 1;
+			var pixelRatio = chart.currentDevicePixelRatio = window.devicePixelRatio || 1;
 
-			if (window.devicePixelRatio !== 1) {
-				ctx.canvas.height = height * window.devicePixelRatio;
-				ctx.canvas.width = width * window.devicePixelRatio;
-				ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
+			if (pixelRatio !== 1) {
+				ctx.canvas.height = height * pixelRatio;
+				ctx.canvas.width = width * pixelRatio;
+				ctx.scale(pixelRatio, pixelRatio);
 
 				ctx.canvas.style.width = width + 'px';
 				ctx.canvas.style.height = height + 'px';
@@ -754,7 +754,7 @@
 				// Store the device pixel ratio so that we can go backwards in `destroy`.
 				// The devicePixelRatio changes with zoom, so there are no guarantees that it is the same
 				// when destroy is called
-				chart.originalDevicePixelRatio = chart.originalDevicePixelRatio || window.devicePixelRatio;
+				chart.originalDevicePixelRatio = chart.originalDevicePixelRatio || pixelRatio;
 			}
 		},
 		//-- Canvas methods


### PR DESCRIPTION
Stored pixel ratio in a variable with a fallback value for browsers that doesn't support `window.devicePixelRatio` fixing rendering issues for IE10 and IE9. (issue #1622)

The old code referenced `window.devicePixelRatio` multiple times without using fallbacks for `undefined` values. This resulted in multiply with 0, setting width and height to 0 on old browsers.