### PR TITLE
Add descriptions for options in documentation.

### DIFF
--- a/docs/01-Scales.md
+++ b/docs/01-Scales.md
@@ -14,39 +14,39 @@ Every scale extends a core scale class with the following options:
 
 Name | Type | Default | Description
 --- |:---:| --- | ---
-display | Boolean | true | If true, show the scale.
-reverse | Boolean | false | If true, reverses the scales.
-gridLines | Array | |
+type | String | Chart specific. | Type of scale being employed. Custom scales can be created. Options: ["category"](#scales-category-scale), ["linear"](#scales-linear-scale), ["logarithmic"](#scales-logarithmic-scale), ["time"](#scales-time-scale), ["radialLinear"](#scales-radial-linear-scale)
+display | Boolean | true | If true, show the scale including gridlines, ticks, and labels. Overrides *gridLines.show*, *scaleLabel.show*, and *ticks.show*.
+**gridLines** | Array | - | Options for the grid lines that run perpendicular to the axis.
 *gridLines*.show | Boolean | true | If true, show the grid lines.
 *gridLines*.color | Color | "rgba(0, 0, 0, 0.1)" | Color of the grid lines.
 *gridLines*.lineWidth | Number | 1 | Width of the grid lines in number of pixels.
-*gridLines*.drawOnChartArea | Boolean | true | If true draw lines on the chart area, if false...
-*gridLines*.drawTicks | Boolean | true |  If true draw ticks in the axis area, if false...
+*gridLines*.drawOnChartArea | Boolean | true | If true, draw lines on the chart area inside the axis lines.
+*gridLines*.drawTicks | Boolean | true |  If true, draw lines beside the ticks in the axis area beside the chart.
 *gridLines*.zeroLineWidth | Number | 1 | Width of the grid line for the first index (index 0).
 *gridLines*.zeroLineColor | Color | "rgba(0, 0, 0, 0.25)" | Color of the grid line for the first index (index 0).
 *gridLines*.offsetGridLines | Boolean | false | If true, offset labels from grid lines.
-scaleLabel | Array | | Label for the axis.
-*scaleLabel*.show | Boolean | false | Whether the label is displayed.
-*scaleLabel*.labelString | String | "" | The text for the label.
-*scaleLabel*.fontColor | Color | "#666" |
-*scaleLabel*.fontFamily| String | "Helvetica Neue" |
-*scaleLabel*.fontSize | Number | 12 |
-*scaleLabel*.fontStyle | String | "normal" |
-ticks | Array | | Settings for the ticks along the axis.
+**scaleLabel** | Array | | Label for the entire axis.
+*scaleLabel*.show | Boolean | false | If true, show the scale label.
+*scaleLabel*.labelString | String | "" | The text for the label. (i.e. "# of People", "Response Choices")
+*scaleLabel*.fontColor | Color | "#666" | Font color for the scale label.
+*scaleLabel*.fontFamily| String | "Helvetica Neue" | Font family for the scale label, follows CSS font-family options.
+*scaleLabel*.fontSize | Number | 12 | Font size for the scale label.
+*scaleLabel*.fontStyle | String | "normal" | Font style for the scale label, follows CSS font-style options (i.e. normal, italic, oblique, initial, inherit).
+**ticks** | Array | | Settings for the labels that run along the axis.
 *ticks*.beginAtZero | Boolean | false | If true the scale will be begin at 0, if false the ticks will begin at your smallest data value.
-*ticks*.fontSize | Number | 12 |
-*ticks*.fontStyle | String | "normal" |
-*ticks*.fontColor | Color | "#666" |
-*ticks*.fontFamily | String | "Helvetica Neue" |
-*ticks*.maxRotation | Number | 90 |
-*ticks*.minRotation | Number |  20 |
-*ticks*.mirror | Boolean | false |
-*ticks*.padding | Number | 10 |
-*ticks*.reverse | Boolean | false |
-*ticks*.show | Boolean | true |
+*ticks*.fontColor | Color | "#666" | Font color for the tick labels.
+*ticks*.fontFamily | String | "Helvetica Neue" | Font family for the tick labels, follows CSS font-family options.
+*ticks*.fontSize | Number | 12 | Font size for the tick labels.
+*ticks*.fontStyle | String | "normal" | Font style for the tick labels, follows CSS font-style options (i.e. normal, italic, oblique, initial, inherit).
+*ticks*.maxRotation | Number | 90 | Maximum rotation for tick labels when rotating to condense labels. Note: Rotation doesn't occur until necessary. *Note: Only applicable to horizontal scales.*
+*ticks*.minRotation | Number |  20 | *currently not-implemented* Minimum rotation for tick labels when condensing is necessary.  *Note: Only applicable to horizontal scales.*
+*ticks*.padding | Number | 10 | Padding between the tick label and the axis. *Note: Only applicable to horizontal scales.*
+*ticks*.mirror | Boolean | false | Flips tick labels around axis, displaying the labels inside the chart instead of outside. *Note: Only applicable to vertical scales.*
+*ticks*.reverse | Boolean | false | Reverses order of tick labels.
+*ticks*.show | Boolean | true | If true, show the ticks.
 *ticks*.suggestedMin | Number | - | User defined minimum number for the scale, overrides minimum value *except for if* it is higher than the minimum value.
 *ticks*.suggestedMax | Number | - | User defined maximum number for the scale, overrides maximum value *except for if* it is lower than the maximum value.
-*ticks*.callback | Function | `function(value) { return '' + value; } ` |
+*ticks*.callback | Function | `function(value) { return '' + value; } ` | Returns the string representation of the tick value as it should be displayed on the chart.
 
 The `userCallback` method may be used for advanced tick customization. The following callback would display every label in scientific notation
 ```javascript

--- a/docs/02-Line-Chart.md
+++ b/docs/02-Line-Chart.md
@@ -122,12 +122,12 @@ stacked | Boolean | false | If true, lines stack on top of each other along the 
 scales | - | - | -
 *scales*.xAxes | Array | `[{type:"category","id":"x-axis-1"}]` | Defines all of the x axes used in the chart. See the [scale documentation](#getting-started-scales) for details on the available options.
 *Options for xAxes* | | |
-type | String | "category" | Type of scale. Built in types are 'category' and 'linear'.
+type | String | "category" | As defined in ["Category"](#scales-category-scale).
 id | String | "x-axis-1" | Id of the axis so that data can bind to it.
  | | |
  *scales*.yAxes | Array | `[{type:"linear","id":"y-axis-1"}]` | Defines all of the x axes used in the chart. See the [scale documentation](#getting-started-scales) for details on the available options.
  *Options for yAxes* | | |
- type | String | "linear" | Type of scale. Built in types are 'category' and 'linear'.
+ type | String | "linear" | As defined in ["Linear"](#scales-linear-scale).
  id | String | "y-axis-1" | Id of the axis so that data can bind to it.
 
 You can override these for your `Chart` instance by passing a member `options` into the `Line` method.

--- a/docs/03-Bar-Chart.md
+++ b/docs/03-Bar-Chart.md
@@ -82,23 +82,23 @@ stacked | Boolean | false |
 scales | Array | - | -
 *scales*.xAxes | Array |  | The bar chart officially supports only 1 x-axis but uses an array to keep the API consistent. Use a scatter chart if you need multiple x axes.
 *Options for xAxes* | | |
-type | String | "Category" |
+type | String | "Category" | As defined in [Scales](#scales-category-scale).
 display | Boolean | true | If true, show the scale.
 position | String | "bottom" | Position of the scale. Options are "top" and "bottom" for dataset scales.
 id | String | "x-axis-1" | Id of the axis so that data can bind to it
-categoryPercentage | Number | 0.8 | Specific to bar chart.
-barPercentage | Number | 0.9 |
+categoryPercentage | Number | 0.8 | Percent (0-1) of the available width (the space between the gridlines for small datasets) for each data-point to use for the bars.
+barPercentage | Number | 0.9 | Percent (0-1) of the available width each bar should be within the category percentage. 1.0 will take the whole category width and put the bars right next to each other.
 gridLines | Array |  [See Scales](#scales) |
-*gridLines*.offsetGridLines | Boolean | true |
+*gridLines*.offsetGridLines | Boolean | true | If true, the bars for a particular data point fall between the grid lines. If false, the grid line will go right down the middle of the bars.
 scaleLabel | Array | [See Scales](#scales) |
 ticks | Array |  [See Scales](#scales) |
 | | |
 *scales*.yAxes | Array | `[{ type: "linear" }]` |
 *Options for xAxes* | | |
-type | String | "linear" |
+type | String | "linear" | As defined in [Scales](#scales-linear-scale).
 display | Boolean | true | If true, show the scale.
 position | String | "left" | Position of the scale. Options are "left" and "right" for dataset scales.
-id | String | "y-axis-1" | Id of the axis so that data can bind to it
+id | String | "y-axis-1" | Id of the axis so that data can bind to it.
 gridLines | Array |  [See Scales](#scales) |
 scaleLabel | Array | [See Scales](#scales) |
 ticks | Array |  [See Scales](#scales) |

--- a/docs/03-Bar-Chart.md
+++ b/docs/03-Bar-Chart.md
@@ -86,8 +86,8 @@ type | String | "Category" | As defined in [Scales](#scales-category-scale).
 display | Boolean | true | If true, show the scale.
 position | String | "bottom" | Position of the scale. Options are "top" and "bottom" for dataset scales.
 id | String | "x-axis-1" | Id of the axis so that data can bind to it
-categoryPercentage | Number | 0.8 | Percent (0-1) of the available width (the space between the gridlines for small datasets) for each data-point to use for the bars.
-barPercentage | Number | 0.9 | Percent (0-1) of the available width each bar should be within the category percentage. 1.0 will take the whole category width and put the bars right next to each other.
+categoryPercentage | Number | 0.8 | Percent (0-1) of the available width (the space between the gridlines for small datasets) for each data-point to use for the bars. [Read More](#bar-chart-barpercentage-vs-categorypercentage)
+barPercentage | Number | 0.9 | Percent (0-1) of the available width each bar should be within the category percentage. 1.0 will take the whole category width and put the bars right next to each other. [Read More](#bar-chart-barpercentage-vs-categorypercentage)
 gridLines | Array |  [See Scales](#scales) |
 *gridLines*.offsetGridLines | Boolean | true | If true, the bars for a particular data point fall between the grid lines. If false, the grid line will go right down the middle of the bars.
 scaleLabel | Array | [See Scales](#scales) |
@@ -130,6 +130,29 @@ new Chart(ctx,{
 
 We can also change these defaults values for each Bar type that is created, this object is available at `Chart.defaults.Bar`.
 
+#### barPercentage vs categoryPercentage
+
+The following shows the relationship between the bar percentage option and the category percentage option.
+
+```text
+// categoryPercentage: 1.0
+// barPercentage: 1.0
+Bar:          | 1.0 | 1.0 |
+Category: 	|    1.0    |   
+Sample:	   |===========|
+
+// categoryPercentage: 1.0
+// barPercentage: 0.5
+Bar:             |.5|  |.5|
+Category: 	|      1.0     |   
+Sample:	   |==============|
+
+// categoryPercentage: 0.5
+// barPercentage: 1.0
+Bar:              |1.||1.|
+Category:     	|  .5  |   
+Sample:	   |==============|
+```
 ### Prototype methods
 
 #### .getBarsAtEvent( event )

--- a/docs/04-Radar-Chart.md
+++ b/docs/04-Radar-Chart.md
@@ -63,10 +63,10 @@ The default options for radar chart are defined in `Chart.defaults.radar`.
 
 Name | Type | Default | Description
 --- | --- | --- | ---
-scale | Array | [See Scales](#scales) and [Defaults for Radial Linear Scale](#getting-started-radial-linear-scale) | Options for the one scale used on the chart. Use this to style the ticks, labels, and grid.
-*scale*.type | String |"radialLinear" | Contains options for the scale.
+scale | Array | [See Scales](#scales) and [Defaults for Radial Linear Scale](#scales-radial-linear-scale) | Options for the one scale used on the chart. Use this to style the ticks, labels, and grid lines.
+*scale*.type | String |"radialLinear" | As defined in ["Radial Linear"](#scales-radial-linear-scale).
 *elements*.line | Array | | Options for all line elements used on the chart, as defined in the global elements, duplicated here to show Radar chart specific defaults.
-*elements.line*.tension | Number | 0 |
+*elements.line*.tension | Number | 0 | Tension exhibited by lines when calculating splineCurve.
 
 You can override these for your `Chart` instance by passing a second argument into the `Radar` method as an object with the keys you want to override.
 

--- a/docs/05-Polar-Area-Chart.md
+++ b/docs/05-Polar-Area-Chart.md
@@ -63,7 +63,7 @@ These are the customisation options specific to Polar Area charts. These options
 Name | Type | Default | Description
 --- | --- | --- | ---
 scale | Array | [See Scales](#scales) and [Defaults for Radial Linear Scale](#getting-started-radial-linear-scale) | Options for the one scale used on the chart. Use this to style the ticks, labels, and grid.
-*scale*.type | String |"radialLinear" | Contains options for the scale.
+*scale*.type | String |"radialLinear" | As defined in ["Radial Linear"](#scales-radial-linear-scale).
 *scale*.lineArc | Boolean | true | When true, lines are circular.
 *animation*.animateRotate | Boolean |true | If true, will animate the rotation of the chart.
 *animation*.animateScale | Boolean | true | If true, will animate scaling the chart.

--- a/docs/06-Pie-Doughnut-Chart.md
+++ b/docs/06-Pie-Doughnut-Chart.md
@@ -75,8 +75,8 @@ Name | Type | Default | Description
 --- | --- | --- | ---
 cutoutPercentage | Number | 50 - for doughnut, 0 - for pie | The percentage of the chart that is cut out of the middle.
 scale | Array | [See Scales](#scales) and [Defaults for Radial Linear Scale](#getting-started-radial-linear-scale) | Options for the one scale used on the chart. Use this to style the ticks, labels, and grid.
-*scale*.type | String |"radialLinear" | Contains options for the scale.
-*scale*.lineArc | Boolean | true | When true, lines are circular.
+*scale*.type | String |"radialLinear" | As defined in ["Radial Linear"](#scales-radial-linear-scale).
+*scale*.lineArc | Boolean | true | When true, lines are arced compared to straight when false.
 *animation*.animateRotate | Boolean |true | If true, will animate the rotation of the chart.
 *animation*.animateScale | Boolean | false | If true, will animate scaling the Doughnut from the centre.
 


### PR DESCRIPTION
Filled out full descriptions for all options tables. Also added "diagram" of bar/category percentage. I know markdown supports images, is that something you guys would rather do? Or is there a way to embed a little HTML snippet that allows the user to change each setting and play around with it.