### PR TITLE
Allow the user to change the time label display formats

### DIFF
--- a/docs/01-Scales.md
+++ b/docs/01-Scales.md
@@ -150,8 +150,19 @@ The time scale extends the core scale class with the following tick template:
 		unit: false,
 		// string - By default, no rounding is applied.  To round, set to a supported time unit eg. 'week', 'month', 'year', etc.
 		round: false,
-		// string - By default, is set to the detected (or manually overridden) time unit's `display` property (see supported time measurements).  To override, use a pattern string from http://momentjs.com/docs/#/displaying/format/
-		displayFormat: false
+		// Moment js for each of the units. Replaces `displayFormat`
+		// To override, use a pattern string from http://momentjs.com/docs/#/displaying/format/
+		displayFormats: {
+				'millisecond': 'SSS [ms]',
+				'second': 'h:mm:ss a', // 11:20:01 AM
+				'minute': 'h:mm:ss a', // 11:20:01 AM
+				'hour': 'MMM D, hA', // Sept 4, 5PM
+				'day': 'll', // Sep 4 2015
+				'week': 'll', // Week 46, or maybe "[W]WW - YYYY" ?
+				'month': 'MMM YYYY', // Sept 2015
+				'quarter': '[Q]Q - YYYY', // Q3
+				'year': 'YYYY', // 2015
+			}, 
 	},
 }
 ```

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -22,44 +22,6 @@
 			'quarter',
 			'year',
 		],
-		unit: {
-			'millisecond': {
-				display: 'SSS [ms]', // 002 ms
-				maxStep: 1000,
-			},
-			'second': {
-				display: 'h:mm:ss a', // 11:20:01 AM
-				maxStep: 60,
-			},
-			'minute': {
-				display: 'h:mm:ss a', // 11:20:01 AM
-				maxStep: 60,
-			},
-			'hour': {
-				display: 'MMM D, hA', // Sept 4, 5PM
-				maxStep: 24,
-			},
-			'day': {
-				display: 'll', // Sep 4 2015
-				maxStep: 7,
-			},
-			'week': {
-				display: 'll', // Week 46, or maybe "[W]WW - YYYY" ?
-				maxStep: 4.3333,
-			},
-			'month': {
-				display: 'MMM YYYY', // Sept 2015
-				maxStep: 12,
-			},
-			'quarter': {
-				display: '[Q]Q - YYYY', // Q3
-				maxStep: 4,
-			},
-			'year': {
-				display: 'YYYY', // 2015
-				maxStep: false,
-			},
-		}
 	};
 
 	var defaultConfig = {
@@ -69,7 +31,20 @@
 			format: false, // false == date objects or use pattern string from http://momentjs.com/docs/#/parsing/string-format/
 			unit: false, // false == automatic or override with week, month, year, etc.
 			round: false, // none, or override with week, month, year, etc.
-			displayFormat: false, // defaults to unit's corresponding unitFormat below or override using pattern string from http://momentjs.com/docs/#/displaying/format/
+			displayFormat: false, // DEPRECATED
+
+			// defaults to unit's corresponding unitFormat below or override using pattern string from http://momentjs.com/docs/#/displaying/format/
+			displayFormats: {
+				'millisecond': 'SSS [ms]',
+				'second': 'h:mm:ss a', // 11:20:01 AM
+				'minute': 'h:mm:ss a', // 11:20:01 AM
+				'hour': 'MMM D, hA', // Sept 4, 5PM
+				'day': 'll', // Sep 4 2015
+				'week': 'll', // Week 46, or maybe "[W]WW - YYYY" ?
+				'month': 'MMM YYYY', // Sept 2015
+				'quarter': '[Q]Q - YYYY', // Q3
+				'year': 'YYYY', // 2015
+			}, 
 		},
 	};
 
@@ -145,7 +120,7 @@
 			// Set unit override if applicable
 			if (this.options.time.unit) {
 				this.tickUnit = this.options.time.unit || 'day';
-				this.displayFormat = time.unit[this.tickUnit].display;
+				this.displayFormat = this.options.time.displayFormats[this.tickUnit];
 				this.tickRange = Math.ceil(this.lastTick.diff(this.firstTick, this.tickUnit, true));
 			} else {
 				// Determine the smallest needed unit of the time
@@ -156,7 +131,7 @@
 				// Start as small as possible
 				this.tickUnit = 'millisecond';
 				this.tickRange = Math.ceil(this.lastTick.diff(this.firstTick, this.tickUnit, true) + buffer);
-				this.displayFormat = time.unit[this.tickUnit].display;
+				this.displayFormat = this.options.time.displayFormats[this.tickUnit];
 
 				// Work our way up to comfort
 				helpers.each(time.units, function(format) {
@@ -165,7 +140,7 @@
 					}
 					this.tickUnit = format;
 					this.tickRange = Math.ceil(this.lastTick.diff(this.firstTick, this.tickUnit) + buffer);
-					this.displayFormat = time.unit[format].display;
+					this.displayFormat = this.options.time.displayFormats[format];
 
 				}, this);
 			}
@@ -202,7 +177,7 @@
 		},
 		convertTicksToLabels: function() {
 			this.ticks = this.ticks.map(function(tick, index, ticks) {
-				var formattedTick = tick.format(this.options.time.displayFormat ? this.options.time.displayFormat : time.unit[this.tickUnit].display);
+				var formattedTick = tick.format(this.options.time.displayFormat ? this.options.time.displayFormat : this.options.time.displayFormats[this.tickUnit]);
 
 				if (this.options.ticks.userCallback) {
 					return this.options.ticks.userCallback(formattedTick, index, ticks);

--- a/test/scale.time.tests.js
+++ b/test/scale.time.tests.js
@@ -53,6 +53,17 @@ describe('Time scale tests', function() {
 				unit: false,
 				round: false,
 				displayFormat: false,
+				displayFormats: {
+					'millisecond': 'SSS [ms]',
+					'second': 'h:mm:ss a', // 11:20:01 AM
+					'minute': 'h:mm:ss a', // 11:20:01 AM
+					'hour': 'MMM D, hA', // Sept 4, 5PM
+					'day': 'll', // Sep 4 2015
+					'week': 'll', // Week 46, or maybe "[W]WW - YYYY" ?
+					'month': 'MMM YYYY', // Sept 2015
+					'quarter': '[Q]Q - YYYY', // Q3
+					'year': 'YYYY', // 2015
+				},
 			}
 		});
 


### PR DESCRIPTION
Fixes #1718 

To change, in your config use
```javascript
config: {
    scales: {
        xAxes: [{
            time: {
                displayFormats: {
                    day: '< moment format string for day unit>'
                }
            }
        }]
    }
}
```