### PR TITLE
Allow time scale to use multiple of base units

### DIFF
--- a/src/core/core.scaleService.js
+++ b/src/core/core.scaleService.js
@@ -93,6 +93,8 @@
 				var horizontalScaleHeight = (height - chartHeight) / (topScales.length + bottomScales.length);
 
 				// Step 4;
+				var maxChartHeight = height - (2 * yPadding);
+				var maxChartWidth = width - (2 * xPadding);
 				var minimumScaleSizes = [];
 
 				var verticalScaleMinSizeFunction = function(scaleInstance) {
@@ -102,15 +104,19 @@
 						minSize: minSize,
 						scale: scaleInstance,
 					});
+
+					maxChartWidth -= minSize.width;
 				};
 
 				var horizontalScaleMinSizeFunction = function(scaleInstance) {
-					var minSize = scaleInstance.update(chartWidth, horizontalScaleHeight);
+					var minSize = scaleInstance.update(maxChartWidth, horizontalScaleHeight);
 					minimumScaleSizes.push({
 						horizontal: true,
 						minSize: minSize,
 						scale: scaleInstance,
 					});
+
+					maxChartHeight -= minSize.height;
 				};
 
 				// vertical scales
@@ -121,22 +127,10 @@
 				helpers.each(topScales, horizontalScaleMinSizeFunction);
 				helpers.each(bottomScales, horizontalScaleMinSizeFunction);
 
-				// Step 5
-				var maxChartHeight = height - (2 * yPadding);
-				var maxChartWidth = width - (2 * xPadding);
-
-				helpers.each(minimumScaleSizes, function(wrapper) {
-					if (wrapper.horizontal) {
-						maxChartHeight -= wrapper.minSize.height;
-					} else {
-						maxChartWidth -= wrapper.minSize.width;
-					}
-				});
-
 				// At this point, maxChartHeight and maxChartWidth are the size the chart area could
 				// be if the axes are drawn at their minimum sizes.
 
-				// Step 6
+				// Steps 5 & 6
 				var verticalScaleFitFunction = function(scaleInstance) {
 					var wrapper = helpers.findNextWhere(minimumScaleSizes, function(wrapper) {
 						return wrapper.scale === scaleInstance;

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -133,6 +133,7 @@
 
 			this.ticks = [];
 			this.labelMoments = [];
+			this.unitScale = 1; // How much we scale the unit by, ie 2 means 2x unit per step 
 
 			this.buildLabelMoments();
 
@@ -152,8 +153,6 @@
 				this.tickRange = Math.ceil(this.lastTick.diff(this.firstTick, this.tickUnit, true) + buffer);
 				this.displayFormat = this.options.time.displayFormats[this.tickUnit];
 
-				// How much we scale the unit by, ie 2 means 2x unit per step 
-				this.unitScale = 1;
 				var unitDefinitionIndex = 0;
 				var unitDefinition = time.units[unitDefinitionIndex];
 


### PR DESCRIPTION
This fixes #1717 and #1598 

The scale service has a minor update to prevent labels from jumping around on horizontal scales and getting cut off.

## Before
![screen shot 2015-12-01 at 9 15 00 pm](https://cloud.githubusercontent.com/assets/6757853/11520361/dcdbc4a6-9870-11e5-8ff1-da40001d79da.png)

## After
![screen shot 2015-12-01 at 9 16 25 pm](https://cloud.githubusercontent.com/assets/6757853/11520396/0a38ae1e-9871-11e5-866f-fb57095de59a.png)


The tick size of the time scale will increase in the following pattern:
* 1 second
* 2 seconds
* 5 seconds
* 10 seconds
* 30 seconds
* 1 minute
* 2 minutes
* 5 minutes
* 10 minutes
* 30 minutes
* 1 hour
* 2 hours
* 3 hours
* 6 hours
* 12 hours
* 1 day
* 2 days
* 5 days
* 1 week
