### PR TITLE
Umd build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,7 +13,8 @@ var gulp = require('gulp'),
 	fs = require('fs'),
 	package = require('./package.json'),
 	bower = require('./bower.json'),
-	karma = require('gulp-karma');
+	karma = require('gulp-karma'),
+	umd = require('gulp-umd');
 
 var srcDir = './src/';
 var testDir = './test/';
@@ -72,6 +73,13 @@ function buildTask() {
 	return gulp.src(srcFiles)
 		.pipe(concat('Chart.js'))
 		.pipe(replace('{{ version }}', package.version))
+		.pipe(umd({
+			// We want a global always to ensure that we match previous behaviour
+			templateName: 'returnExportsGlobal',
+			dependencies: function() {
+				return ['moment']
+			}
+		}))
 		.pipe(gulp.dest(outputDir))
 		.pipe(uglify({
 			preserveComments: 'some'

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "karma-firefox-launcher": "^0.1.6",
     "karma-jasmine": "^0.3.6",
     "karma-jasmine-html-reporter": "^0.1.8",
-    "semver": "^3.0.1"
+    "semver": "^3.0.1",
+    "gulp-umd": "~0.2.0"
   },
   "spm": {
     "main": "Chart.js"

--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -246,9 +246,10 @@
 		})(),
 		warn = helpers.warn = function(str) {
 			//Method for warning of errors
-			if (window.console && typeof window.console.warn === "function") console.warn(str);
+			if (console && typeof console.warn === "function") {
+				console.warn(str);
+			}
 		},
-		amd = helpers.amd = (typeof define === 'function' && define.amd),
 		//-- Math methods
 		isNumber = helpers.isNumber = function(n) {
 			return !isNaN(parseFloat(n)) && isFinite(n);
@@ -787,11 +788,11 @@
 			ctx.closePath();
 		},
 		color = helpers.color = function(color) {
-			if (!window.Color) {
+			if (!root.Color) {
 				console.log('Color.js not found!');
 				return color;
 			}
-			return window.Color(color);
+			return root.Color(color);
 		},
 		addResizeListener = helpers.addResizeListener = function(node, callback) {
 			// Hide an iframe before the node

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -109,14 +109,6 @@
 		},
 	};
 
-	if (typeof amd !== 'undefined') {
-		define(function() {
-			return Chart;
-		});
-	} else if (typeof module === 'object' && module.exports) {
-		module.exports = Chart;
-	}
-
 	root.Chart = Chart;
 
 	Chart.noConflict = function() {

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -1,7 +1,7 @@
-(function() {
+(function(moment) {
 	"use strict";
 
-	if (!window.moment) {
+	if (!moment) {
 		console.warn('Chart.js - Moment.js could not be found! You must include it before Chart.js to use the time scale. Download at http://momentjs.com/');
 		return;
 	}
@@ -226,4 +226,4 @@
 	});
 	Chart.scaleService.registerScaleType("time", TimeScale, defaultConfig);
 
-}).call(this);
+}).call(this, moment);


### PR DESCRIPTION
Builds Chart.js with proper UMD headers via [gulp-umd](https://github.com/eduardolundgren/gulp-umd)

### Time Scale
The time scale uses moment.js as provided through the UMD headers instead of relying on `window.moment`. This fixes #1614

### Color 
Use `root.color` instead of `window.color`

### Testing
Tested by modifying one of the time scale samples to load Chart.js using requirejs. Moment was loaded correctly and used with no issues. No issues were seen when require was not used.