### PR TITLE
Gracefully handle setting `options.animation` to `false` 

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -229,7 +229,7 @@
 
 		render: function render(duration, lazy) {
 
-			if ((typeof duration !== 'undefined' && duration !== 0) || (typeof duration == 'undefined' && this.options.animation.duration !== 0)) {
+			if (this.options.animation !== false && ((typeof duration !== 'undefined' && duration !== 0) || (typeof duration == 'undefined' && this.options.animation.duration !== 0))) {
 				var animation = new Chart.Animation();
 				animation.numSteps = (duration || this.options.animation.duration) / 16.66; //60 fps
 				animation.easing = this.options.animation.easing;


### PR DESCRIPTION
This occurs when migrating configs from v1.

Fixes #1576 