### PR TITLE
Lowercase NPM package name

### DIFF
--- a/docs/00-Getting-Started.md
+++ b/docs/00-Getting-Started.md
@@ -31,7 +31,7 @@ You can also grab Chart.js using bower, npm, or CDN:
 bower install Chart.js --save
 ```
 ```bash
-npm install Chart.js --save
+npm install chart.js --save
 ```
 
 https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.0.0-beta/Chart.js


### PR DESCRIPTION
Latest version of NPM complains if the package name contains capital letters and will not install.