### PR TITLE
Remove Firefox workaround

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -40,10 +40,6 @@
 		var width = this.width = computeDimension(context.canvas,'Width') || context.canvas.width;
 		var height = this.height = computeDimension(context.canvas,'Height') || context.canvas.height;
 
-		// Firefox requires this to work correctly
-		context.canvas.width  = width;
-		context.canvas.height = height;
-
 		width = this.width = context.canvas.width;
 		height = this.height = context.canvas.height;
 		this.aspectRatio = this.width / this.height;


### PR DESCRIPTION
The workaround for older Firefox should be removed, because latest
supported Firefox 38.4.0/42.0 do not require it.
And it has side effect like #1198 or my problem on Kintone on cybozu.com.