### PR TITLE
maxRotation test is off by one

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -180,7 +180,7 @@
 				var tickWidth = this.getPixelForTick(1) - this.getPixelForTick(0) - 6;
 
 				//Max label rotation can be set or default to 90 - also act as a loop counter
-				while (this.labelWidth > tickWidth && this.labelRotation <= this.options.ticks.maxRotation) {
+				while (this.labelWidth > tickWidth && this.labelRotation < this.options.ticks.maxRotation) {
 					cosRotation = Math.cos(helpers.toRadians(this.labelRotation));
 					sinRotation = Math.sin(helpers.toRadians(this.labelRotation));
 


### PR DESCRIPTION
Most notable when maxRotation=0 and you end up with the text becoming non centred as it has rotated it by 1 and switched to right alligned mode.