### PR TITLE
Fix ticks callback and auto skip

### DIFF
--- a/docs/01-Scales.md
+++ b/docs/01-Scales.md
@@ -48,6 +48,7 @@ display | Boolean | true | If true, show the scale including gridlines, ticks, a
 *ticks*.suggestedMax | Number | - | User defined maximum number for the scale, overrides maximum value *except for if* it is lower than the maximum value.
 *ticks*.min | Number | - | User defined minimum number for the scale, overrides minimum value
 *ticks*.max | Number | - | User defined minimum number for the scale, overrides maximum value
+*ticks*.autoSkip | Boolean | true | If true, automatically calculates how many labels that can be shown and hides labels accordingly. Turn it off to show all labels no matter what
 *ticks*.callback | Function | `function(value) { return '' + value; } ` | Returns the string representation of the tick value as it should be displayed on the chart.
 
 The `callback` method may be used for advanced tick customization. The following callback would display every label in scientific notation

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -406,10 +406,6 @@
 				var scaleLabelY;
 				var useAutoskipper = this.options.ticks.autoSkip;
 
-				if(this.options.ticks.userCallback) {
-					useAutoskipper = false;
-				}
-
 				// Make sure we draw text in the correct color and font
 				this.ctx.fillStyle = this.options.ticks.fontColor;
 				var labelFont = helpers.fontString(this.options.ticks.fontSize, this.options.ticks.fontStyle, this.options.ticks.fontFamily);

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -46,6 +46,7 @@
 			padding: 10,
 			reverse: false,
 			display: true,
+			autoSkip: true,
 			callback: function(value) {
 				return '' + value;
 			},
@@ -403,6 +404,11 @@
 				var skipRatio;
 				var scaleLabelX;
 				var scaleLabelY;
+				var useAutoskipper = this.options.ticks.autoSkip;
+
+				if(this.options.ticks.userCallback) {
+					useAutoskipper = false;
+				}
 
 				// Make sure we draw text in the correct color and font
 				this.ctx.fillStyle = this.options.ticks.fontColor;
@@ -418,6 +424,10 @@
 						skipRatio = 1 + Math.floor(((this.options.ticks.fontSize + 4) * this.ticks.length) / (this.width - (this.paddingLeft + this.paddingRight)));
 					}
 
+					if (!useAutoskipper) {
+						skipRatio = false;
+					}
+					
 					helpers.each(this.ticks, function(label, index) {
 						// Blank ticks
 						if ((skipRatio > 1 && index % skipRatio > 0) || (label === undefined || label === null)) {

--- a/test/core.helpers.tests.js
+++ b/test/core.helpers.tests.js
@@ -244,6 +244,7 @@ describe('Core helper tests', function() {
 						reverse: false,
 						display: true,
 						callback: merged.scales.yAxes[1].ticks.callback, // make it nicer, then check explicitly below
+						autoSkip: true
 					},
 					type: 'linear'
 				}, {
@@ -280,6 +281,7 @@ describe('Core helper tests', function() {
 						reverse: false,
 						display: true,
 						callback: merged.scales.yAxes[2].ticks.callback, // make it nicer, then check explicitly below
+						autoSkip: true
 					},
 					type: 'linear'
 				}]

--- a/test/scale.category.tests.js
+++ b/test/scale.category.tests.js
@@ -43,6 +43,7 @@ describe('Category scale tests', function() {
 				reverse: false,
 				display: true,
 				callback: defaultConfig.ticks.callback,  // make this nicer, then check explicitly below
+				autoSkip: true
 			}
 		});
 

--- a/test/scale.linear.tests.js
+++ b/test/scale.linear.tests.js
@@ -42,6 +42,7 @@ describe('Linear Scale', function() {
 				reverse: false,
 				display: true,
 				callback: defaultConfig.ticks.callback, // make this work nicer, then check below
+				autoSkip: true
 			}
 		});
 

--- a/test/scale.logarithmic.tests.js
+++ b/test/scale.logarithmic.tests.js
@@ -41,6 +41,7 @@ describe('Logarithmic Scale tests', function() {
 				reverse: false,
 				display: true,
 				callback: defaultConfig.ticks.callback, // make this nicer, then check explicitly below
+				autoSkip: true
 			},
 		});
 

--- a/test/scale.radialLinear.tests.js
+++ b/test/scale.radialLinear.tests.js
@@ -58,7 +58,7 @@ describe('Test the radial linear scale', function() {
 				showLabelBackdrop: true,
 				display: true,
 				callback: defaultConfig.ticks.callback, // make this nicer, then check explicitly below
-
+				autoSkip: true
 			},
 		});
 

--- a/test/scale.time.tests.js
+++ b/test/scale.time.tests.js
@@ -45,7 +45,8 @@ describe('Time scale tests', function() {
 				padding: 10,
 				reverse: false,
 				display: true,
-				callback: defaultConfig.ticks.callback, // make this nicer, then check explicitly below
+				callback: defaultConfig.ticks.callback, // make this nicer, then check explicitly below,
+				autoSkip: true
 			},
 			time: {
 				format: false,


### PR DESCRIPTION
As explained in #1800 the ticks callbacks have some unexpected behavior where labels you return and expect to see still can be filtered out since the auto skip functionality always runs.

This fixes it by disabling the auto skipper if there is a `userCallback` is defined (or if the user has set `autoSkip` to true in config).