### PR TITLE
Refactored skipRatio to use the longest label text for calculation.

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -47,6 +47,7 @@
 			reverse: false,
 			display: true,
 			autoSkip: true,
+		    autoSkipPadding: 20,
 			callback: function(value) {
 				return '' + value;
 			},
@@ -455,7 +456,7 @@
 					skipRatio = false;
 
 					if ((this.options.ticks.fontSize * maxLength) * this.ticks.length > (this.width - (this.paddingLeft + this.paddingRight))) {
-					    skipRatio = 1 + Math.floor((((this.options.ticks.fontSize * maxLength / 2) + (this.options.ticks.autoSkipPadding || 20)) * this.ticks.length) / (this.width - (this.paddingLeft + this.paddingRight)));
+					    skipRatio = 1 + Math.floor((((this.options.ticks.fontSize * maxLength / 2) + this.options.ticks.autoSkipPadding) * this.ticks.length) / (this.width - (this.paddingLeft + this.paddingRight)));
 					}
 
 					if (!useAutoskipper) {

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -454,8 +454,8 @@
 					var yTickEnd = this.options.position === "bottom" ? this.top + 10 : this.bottom;
 					skipRatio = false;
 
-					if ((this.options.ticks.fontSize + 4) * this.ticks.length > (this.width - (this.paddingLeft + this.paddingRight))) {
-						skipRatio = 1 + Math.floor(((this.options.ticks.fontSize + 4) * this.ticks.length) / (this.width - (this.paddingLeft + this.paddingRight)));
+					if ((this.options.ticks.fontSize * maxLength) * this.ticks.length > (this.width - (this.paddingLeft + this.paddingRight))) {
+					    skipRatio = 1 + Math.floor((((this.options.ticks.fontSize * maxLength / 2) + (this.options.ticks.autoSkipPadding || 20)) * this.ticks.length) / (this.width - (this.paddingLeft + this.paddingRight)));
 					}
 
 					if (!useAutoskipper) {

--- a/test/core.helpers.tests.js
+++ b/test/core.helpers.tests.js
@@ -244,7 +244,8 @@ describe('Core helper tests', function() {
 						reverse: false,
 						display: true,
 						callback: merged.scales.yAxes[1].ticks.callback, // make it nicer, then check explicitly below
-						autoSkip: true
+						autoSkip: true,
+						autoSkipPadding: 20
 					},
 					type: 'linear'
 				}, {
@@ -281,7 +282,8 @@ describe('Core helper tests', function() {
 						reverse: false,
 						display: true,
 						callback: merged.scales.yAxes[2].ticks.callback, // make it nicer, then check explicitly below
-						autoSkip: true
+						autoSkip: true,
+						autoSkipPadding: 20
 					},
 					type: 'linear'
 				}]

--- a/test/scale.category.tests.js
+++ b/test/scale.category.tests.js
@@ -43,7 +43,8 @@ describe('Category scale tests', function() {
 				reverse: false,
 				display: true,
 				callback: defaultConfig.ticks.callback,  // make this nicer, then check explicitly below
-				autoSkip: true
+				autoSkip: true,
+				autoSkipPadding: 20
 			}
 		});
 

--- a/test/scale.linear.tests.js
+++ b/test/scale.linear.tests.js
@@ -42,7 +42,8 @@ describe('Linear Scale', function() {
 				reverse: false,
 				display: true,
 				callback: defaultConfig.ticks.callback, // make this work nicer, then check below
-				autoSkip: true
+				autoSkip: true,
+				autoSkipPadding: 20
 			}
 		});
 

--- a/test/scale.logarithmic.tests.js
+++ b/test/scale.logarithmic.tests.js
@@ -41,7 +41,8 @@ describe('Logarithmic Scale tests', function() {
 				reverse: false,
 				display: true,
 				callback: defaultConfig.ticks.callback, // make this nicer, then check explicitly below
-				autoSkip: true
+				autoSkip: true,
+				autoSkipPadding: 20
 			},
 		});
 

--- a/test/scale.radialLinear.tests.js
+++ b/test/scale.radialLinear.tests.js
@@ -58,7 +58,8 @@ describe('Test the radial linear scale', function() {
 				showLabelBackdrop: true,
 				display: true,
 				callback: defaultConfig.ticks.callback, // make this nicer, then check explicitly below
-				autoSkip: true
+				autoSkip: true,
+				autoSkipPadding: 20
 			},
 		});
 

--- a/test/scale.time.tests.js
+++ b/test/scale.time.tests.js
@@ -46,7 +46,8 @@ describe('Time scale tests', function() {
 				reverse: false,
 				display: true,
 				callback: defaultConfig.ticks.callback, // make this nicer, then check explicitly below,
-				autoSkip: true
+				autoSkip: true,
+				autoSkipPadding: 20
 			},
 			time: {
 				format: false,


### PR DESCRIPTION
Refactored the skipRatio calculation to use the longest label text for calculations.
Also added this.options.ticks.autoSkipPadding that sets the padding between each label.

PS: fontsize / 2 might not be the best way to find the width as fonts will vary.