### PR TITLE
Tweaked helper.longestText to only measure the longest string

### DIFF
--- a/src/core/core.helpers.js
+++ b/src/core/core.helpers.js
@@ -771,11 +771,16 @@
 		longestText = helpers.longestText = function(ctx, font, arrayOfStrings) {
 			ctx.font = font;
 			var longest = 0;
-			each(arrayOfStrings, function(string) {
-				var textWidth = ctx.measureText(string).width;
-				longest = (textWidth > longest) ? textWidth : longest;
+			var longestString = "";
+			
+			each(arrayOfStrings, function (string) {
+				if (string != null && string.length > longest) {
+					longest = string.length;
+					longestString = string;
+				}
 			});
-			return longest;
+			
+			return ctx.measureText(longestString).width;
 		},
 		drawRoundedRectangle = helpers.drawRoundedRectangle = function(ctx, x, y, width, height, radius) {
 			ctx.beginPath();


### PR DESCRIPTION
This helper is used quite a bit and should be as fast as possible.

I tweaked it to only actually measure the longest string. This makes it run in about 1/10 of the original time.

PS: This would evaluate "....." as longer than "OOOO". But I find it likely that all ticks have roughly the same format and therefor this should work as expected.