### PR TITLE
Fixed bug with bezier still being used with tension set to 0

### DIFF
--- a/src/elements/element.line.js
+++ b/src/elements/element.line.js
@@ -37,7 +37,7 @@
 				skipHandler.call(this, previousPoint, point, nextPoint); 
 			} else if (previousPoint._view.skip) {
 				previousSkipHandler.call(this, previousPoint, point, nextPoint);
-			} else if (this._chart.config.options.elements.line.tension === 0) { 
+			} else if (point._view.tension === 0) { 
 				ctx.lineTo(point._view.x, point._view.y);
 			} else {
 				// Line between points

--- a/src/elements/element.line.js
+++ b/src/elements/element.line.js
@@ -37,6 +37,8 @@
 				skipHandler.call(this, previousPoint, point, nextPoint); 
 			} else if (previousPoint._view.skip) {
 				previousSkipHandler.call(this, previousPoint, point, nextPoint);
+			} else if (this._chart.config.options.elements.line.tension === 0) { 
+				ctx.lineTo(point._view.x, point._view.y);
 			} else {
 				// Line between points
 				ctx.bezierCurveTo(


### PR DESCRIPTION
According to the docs bezier curve should be disabled when tension is set to 0.