### PR TITLE
Issue 1764: Add default colors for Pie Charts

### DIFF
--- a/docs/05-Pie-Doughnut-Chart.md
+++ b/docs/05-Pie-Doughnut-Chart.md
@@ -137,6 +137,8 @@ myDoughnutChart.update();
 
 Calling `addData(segmentData, index)` on your Chart instance passing an object in the same format as in the constructor. There is an optional second argument of 'index', this determines at what index the new segment should be inserted into the chart.
 
+If you don't specify a color and highliht, one will be chosen from the global default array: segmentColorDefault and the corresponding segmentHighlightColorDefault.  The index of the addded data is used to lookup a corresponding color from the defaults.
+
 ```javascript
 // An object in the same format as the original data source
 myDoughnutChart.addData({

--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -173,6 +173,12 @@
 			// String - Colour behind the legend colour block
 			multiTooltipKeyBackground: '#fff',
 
+            // Array - A list of colors to use as the defaults
+            segmentColorDefault: ["#668CFF", "#8C66FF", "#D966FF", "#FF66D9", "#FF668C", "#FF8C66", "#FFD966", "#D9FF66", "#8CFF66", "#66FF8C", "#66FFD9", "#66D9FF", "#295EFF", "#003BEB", "#FFC929"],
+
+            // Array - A list of highlight colors to use as the defaults
+            segmentHighlightColorDefaults: ["#6633FF", "#CC33FF", "#FF33CC", "#FF3366", "#FF6633", "#FFCC33", "#CCFF33", "#66FF33", "#33FF66", "#33FFCC", "#33CCFF", "#003DF5", "#002EB8", "#F5B800", "#B88A00"],
+
 			// Function - Will fire on animation progression.
 			onAnimationProgress: function(){},
 

--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -174,10 +174,10 @@
 			multiTooltipKeyBackground: '#fff',
 
 			// Array - A list of colors to use as the defaults
-			segmentColorDefault: ["#668CFF", "#8C66FF", "#D966FF", "#FF66D9", "#FF668C", "#FF8C66", "#FFD966", "#D9FF66", "#8CFF66", "#66FF8C", "#66FFD9", "#66D9FF", "#295EFF", "#003BEB", "#FFC929"],
+			segmentColorDefault: ["#A6CEE3", "#1F78B4", "#B2DF8A", "#33A02C", "#FB9A99", "#E31A1C", "#FDBF6F", "#FF7F00", "#CAB2D6", "#6A3D9A", "#B4B482", "#B15928" ],
 
 			// Array - A list of highlight colors to use as the defaults
-			segmentHighlightColorDefaults: ["#6633FF", "#CC33FF", "#FF33CC", "#FF3366", "#FF6633", "#FFCC33", "#CCFF33", "#66FF33", "#33FF66", "#33FFCC", "#33CCFF", "#003DF5", "#002EB8", "#F5B800", "#B88A00"],
+			segmentHighlightColorDefaults: [ "#CEF6FF", "#47A0DC", "#DAFFB2", "#5BC854", "#FFC2C1", "#FF4244", "#FFE797", "#FFA728", "#F2DAFE", "#9265C2", "#DCDCAA", "#D98150" ],
 
 			// Function - Will fire on animation progression.
 			onAnimationProgress: function(){},

--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -173,11 +173,11 @@
 			// String - Colour behind the legend colour block
 			multiTooltipKeyBackground: '#fff',
 
-            // Array - A list of colors to use as the defaults
-            segmentColorDefault: ["#668CFF", "#8C66FF", "#D966FF", "#FF66D9", "#FF668C", "#FF8C66", "#FFD966", "#D9FF66", "#8CFF66", "#66FF8C", "#66FFD9", "#66D9FF", "#295EFF", "#003BEB", "#FFC929"],
+			// Array - A list of colors to use as the defaults
+			segmentColorDefault: ["#668CFF", "#8C66FF", "#D966FF", "#FF66D9", "#FF668C", "#FF8C66", "#FFD966", "#D9FF66", "#8CFF66", "#66FF8C", "#66FFD9", "#66D9FF", "#295EFF", "#003BEB", "#FFC929"],
 
-            // Array - A list of highlight colors to use as the defaults
-            segmentHighlightColorDefaults: ["#6633FF", "#CC33FF", "#FF33CC", "#FF3366", "#FF6633", "#FFCC33", "#CCFF33", "#66FF33", "#33FF66", "#33FFCC", "#33CCFF", "#003DF5", "#002EB8", "#F5B800", "#B88A00"],
+			// Array - A list of highlight colors to use as the defaults
+			segmentHighlightColorDefaults: ["#6633FF", "#CC33FF", "#FF33CC", "#FF3366", "#FF6633", "#FFCC33", "#CCFF33", "#66FF33", "#33FF66", "#33FFCC", "#33CCFF", "#003DF5", "#002EB8", "#F5B800", "#B88A00"],
 
 			// Function - Will fire on animation progression.
 			onAnimationProgress: function(){},

--- a/src/Chart.Doughnut.js
+++ b/src/Chart.Doughnut.js
@@ -92,6 +92,10 @@
 		},
 		addData : function(segment, atIndex, silent){
 			var index = atIndex !== undefined ? atIndex : this.segments.length;
+			if ( typeof(segment.color) === "undefined" ) {
+                segment.color = Chart.defaults.global.segmentColorDefault[index];
+                segment.highlight = Chart.defaults.global.segmentHighlightColorDefaults[index];				
+			}
 			this.segments.splice(index, 0, new this.SegmentArc({
 				value : segment.value,
 				outerRadius : (this.options.animateScale) ? 0 : this.outerRadius,

--- a/src/Chart.Doughnut.js
+++ b/src/Chart.Doughnut.js
@@ -93,8 +93,8 @@
 		addData : function(segment, atIndex, silent){
 			var index = atIndex !== undefined ? atIndex : this.segments.length;
 			if ( typeof(segment.color) === "undefined" ) {
-				segment.color = Chart.defaults.global.segmentColorDefault[index];
-				segment.highlight = Chart.defaults.global.segmentHighlightColorDefaults[index];				
+				segment.color = Chart.defaults.global.segmentColorDefault[index % Chart.defaults.global.segmentColorDefault.length];
+				segment.highlight = Chart.defaults.global.segmentHighlightColorDefaults[index % Chart.defaults.global.segmentHighlightColorDefaults.length];				
 			}
 			this.segments.splice(index, 0, new this.SegmentArc({
 				value : segment.value,

--- a/src/Chart.Doughnut.js
+++ b/src/Chart.Doughnut.js
@@ -93,8 +93,8 @@
 		addData : function(segment, atIndex, silent){
 			var index = atIndex !== undefined ? atIndex : this.segments.length;
 			if ( typeof(segment.color) === "undefined" ) {
-                segment.color = Chart.defaults.global.segmentColorDefault[index];
-                segment.highlight = Chart.defaults.global.segmentHighlightColorDefaults[index];				
+				segment.color = Chart.defaults.global.segmentColorDefault[index];
+				segment.highlight = Chart.defaults.global.segmentHighlightColorDefaults[index];				
 			}
 			this.segments.splice(index, 0, new this.SegmentArc({
 				value : segment.value,


### PR DESCRIPTION
I wrote a simple fix for default colors on the pie chart.

Here's the basic idea:

1. Create 2 new arrays in the global.defaults
 * segmentColorDefaults
 * segmentHighlightColorDefaults
2. Populate each of these arrays with a list of colors (ie: #AABBCC)
3. Update the "addData" routine on the Pie Chart so that, if a color is not specified, a color and highlight color is chosen from the defaults
 * For simplicity, the index of the item which is being added is used to look up the corresponding color in the list of default colors
      * I suppose I could use a stack of some sort and pop off the top each time a color is used, but that's more than I'm up for at this moment

Users can then override the list of default colors/highlights at a global level should they feel the predefined ones are not adequate/enough.  Failure to define colors will simply roll over to the defaults.