### PR TITLE
Add suggestedMin, suggestedMax, min, and max options to radialLinear scale

### DIFF
--- a/src/scales/scale.radialLinear.js
+++ b/src/scales/scale.radialLinear.js
@@ -90,11 +90,6 @@
 				}
 			}, this);
 
-			if (this.min === this.max) {
-				this.min--;
-				this.max++;
-			}
-
 			// If we are forcing it to begin at 0, but 0 will already be rendered on the chart,
 			// do nothing since that would make the chart weird. If the user really wants a weird chart
 			// axis, they can manually override it
@@ -109,6 +104,23 @@
 					// move the botttom down to 0
 					this.min = 0;
 				}
+			}
+
+			if (this.options.ticks.min !== undefined) {
+				this.min = this.options.ticks.min;
+			} else if (this.options.ticks.suggestedMin !== undefined) {
+				this.min = Math.min(this.min, this.options.ticks.suggestedMin);
+			}
+
+			if (this.options.ticks.max !== undefined) {
+				this.max = this.options.ticks.max;
+			} else if (this.options.ticks.suggestedMax !== undefined) {
+				this.max = Math.max(this.max, this.options.ticks.suggestedMax);
+			}
+
+			if (this.min === this.max) {
+				this.min--;
+				this.max++;
 			}
 		},
 		buildTicks: function() {
@@ -133,10 +145,14 @@
 			var niceMin = Math.floor(this.min / spacing) * spacing;
 			var niceMax = Math.ceil(this.max / spacing) * spacing;
 
+			var numSpaces = Math.ceil((niceMax - niceMin) / spacing);
+
 			// Put the values into the ticks array
-			for (var j = niceMin; j <= niceMax; j += spacing) {
-				this.ticks.push(j);
+			this.ticks.push(this.options.ticks.min !== undefined ? this.options.ticks.min : niceMin);
+			for (var j = 1; j < numSpaces; ++j) {
+				this.ticks.push(niceMin + (j * spacing));
 			}
+			this.ticks.push(this.options.ticks.max !== undefined ? this.options.ticks.max : niceMax);
 
 			// At this point, we need to update our max and min given the tick values since we have expanded the
 			// range of the scale

--- a/test/scale.radialLinear.tests.js
+++ b/test/scale.radialLinear.tests.js
@@ -185,6 +185,73 @@ describe('Test the radial linear scale', function() {
 		expect(scale.max).toBe(1);
 	});
 
+	it('Should use the suggestedMin and suggestedMax options', function() {
+		var scaleID = 'myScale';
+
+		var mockData = {
+			datasets: [{
+				yAxisID: scaleID,
+				data: [1, 1, 1, 2, 1, 0]
+			}],
+			labels: ['lablel1', 'label2', 'label3', 'label4', 'label5', 'label6']
+		};
+
+		var config = Chart.helpers.clone(Chart.scaleService.getScaleDefaults('radialLinear'));
+		config.ticks.suggestedMin = -10;
+		config.ticks.suggestedMax = 10;
+
+		var mockContext = window.createMockContext();
+		var Constructor = Chart.scaleService.getScaleConstructor('radialLinear');
+		var scale = new Constructor({
+			ctx: mockContext,
+			options: config,
+			chart: {
+				data: mockData
+			},
+			id: scaleID
+		});
+
+		// Set arbitrary width and height for now
+		scale.update(200, 300);
+		expect(scale.min).toBe(-10);
+		expect(scale.max).toBe(10);
+	});
+
+	it('Should use the min and max options', function() {
+		var scaleID = 'myScale';
+
+		var mockData = {
+			datasets: [{
+				yAxisID: scaleID,
+				data: [1, 1, 1, 2, 1, 0]
+			}],
+			labels: ['lablel1', 'label2', 'label3', 'label4', 'label5', 'label6']
+		};
+
+		var config = Chart.helpers.clone(Chart.scaleService.getScaleDefaults('radialLinear'));
+		config.ticks.min = -1010;
+		config.ticks.max = 1010;
+
+		var mockContext = window.createMockContext();
+		var Constructor = Chart.scaleService.getScaleConstructor('radialLinear');
+		var scale = new Constructor({
+			ctx: mockContext,
+			options: config,
+			chart: {
+				data: mockData
+			},
+			id: scaleID
+		});
+
+		// Set arbitrary width and height for now
+		scale.update(200, 300);
+		expect(scale.min).toBe(-1010);
+		expect(scale.max).toBe(1010);
+		expect(scale.ticks[0]).toBe('-1010');
+		expect(scale.ticks[scale.ticks.length - 1]).toBe('1010');
+		expect(scale.ticks).toEqual(['-1010', '-1000', '0', '1000', '1010']);
+	});
+
 	it('should forcibly include 0 in the range if the beginAtZero option is used', function() {
 		var scaleID = 'myScale';
 


### PR DESCRIPTION
Fixes #1461 

You can now set 4 new options in the radialLinear scale
`ticks.suggestedMin`
`ticks.suggestedMax`
`ticks.min`
`ticks.max`

These options are already in the linear scale and behave the same way.