### PR TITLE
Update gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -86,7 +86,7 @@ function buildTask() {
 				"  }\n"+
 				"}(this || window, function(<%= param %>) {\n"+
 				"<%= contents %>\n"+
-				"return <%= exports %>;\n"+
+				"return this.<%= exports %>;\n"+
 				"}));\n",
 			dependencies: function() {
 				return ['moment']


### PR DESCRIPTION
`root` can be either `window or globals` (given configuration) but without `this`, JS will not lookup in `globals` object (only in `window`)

Setup:
Using browserify and require('chart.js')
The error I saw previously was:
```
chart.js:7209         Uncaught ReferenceError: Chart is not defined
```