### PR TITLE
Fixes the point size for rect and rectRot

### DIFF
--- a/src/elements/element.point.js
+++ b/src/elements/element.point.js
@@ -96,14 +96,14 @@
 						ctx.fill();
 					break;
 					case 'rect':
-						ctx.fillRect(vm.x - radius, vm.y - radius, 2 * radius, 2 * radius);
-						ctx.strokeRect(vm.x - radius, vm.y - radius, 2 * radius, 2 * radius);
+						ctx.fillRect(vm.x - 1 / Math.SQRT2 * radius, vm.y - 1 / Math.SQRT2 * radius, 2 / Math.SQRT2 * radius, 2 / Math.SQRT2 * radius);
+						ctx.strokeRect(vm.x - 1 / Math.SQRT2 * radius, vm.y - 1 / Math.SQRT2 * radius, 2 / Math.SQRT2 * radius, 2 / Math.SQRT2 * radius);
 					break;
 					case 'rectRot':
 						ctx.translate(vm.x, vm.y);
 						ctx.rotate(Math.PI / 4);
-						ctx.fillRect(-radius, -radius, 2 * radius, 2 * radius);
-						ctx.strokeRect(-radius, -radius, 2 * radius, 2 * radius);
+						ctx.fillRect(-1 / Math.SQRT2 * radius, -1 / Math.SQRT2 * radius, 2 / Math.SQRT2 * radius, 2 / Math.SQRT2 * radius);
+						ctx.strokeRect(-1 / Math.SQRT2 * radius, -1 / Math.SQRT2 * radius, 2 / Math.SQRT2 * radius, 2 / Math.SQRT2 * radius);
 						ctx.setTransform(1, 0, 0, 1, 0, 0);
 					break;
 					case 'cross':

--- a/test/element.point.tests.js
+++ b/test/element.point.tests.js
@@ -166,10 +166,10 @@ describe('Point element tests', function() {
 			args: ['rgba(0, 255, 0)']
 		}, {
 			name: 'fillRect',
-			args: [8, 13, 4, 4]
+			args: [10 - 1 / Math.SQRT2 * 2, 15 - 1 / Math.SQRT2 * 2, 2 / Math.SQRT2 * 2, 2 / Math.SQRT2 * 2]
 		}, {
 			name: 'strokeRect',
-			args: [8, 13, 4, 4]
+			args: [10 - 1 / Math.SQRT2 * 2, 15 - 1 / Math.SQRT2 * 2, 2 / Math.SQRT2 * 2, 2 / Math.SQRT2 * 2]
 		}, {
 			name: 'stroke',
 			args: []
@@ -196,10 +196,10 @@ describe('Point element tests', function() {
 			args: [Math.PI / 4]
 		}, {
 			name: 'fillRect',
-			args: [-2, -2, 4, 4],
+			args: [-1 / Math.SQRT2 * 2, -1 / Math.SQRT2 * 2, 2 / Math.SQRT2 * 2, 2 / Math.SQRT2 * 2],
 		}, {
 			name: 'strokeRect',
-			args: [-2, -2, 4, 4],
+			args: [-1 / Math.SQRT2 * 2, -1 / Math.SQRT2 * 2, 2 / Math.SQRT2 * 2, 2 / Math.SQRT2 * 2],
 		}, {
 			name: 'setTransform',
 			args: [1, 0, 0, 1, 0, 0],


### PR DESCRIPTION
I sized every shape the way that the circumscribed circle matches the default circle radius. Missed this for rect and rectRot.

/cc @etimberg 