### PR TITLE
Ensure that adding datasets to charts with time scales works 

### DIFF
--- a/samples/timeScale/combo-time-scale.html
+++ b/samples/timeScale/combo-time-scale.html
@@ -74,6 +74,7 @@
 				}, ]
 			},
 			options: {
+				showLines: true,
 				responsive: true,
 				scales: {
 					xAxes: [{
@@ -144,10 +145,7 @@
 
 		$('#addData').click(function() {
 			if (config.data.datasets.length > 0) {
-				config.data.labels.push(
-					myLine.scales['x-axis-0'].labelMoments[myLine.scales['x-axis-0'].labelMoments.length - 1].add(1, 'day')
-					.format('MM/DD/YYYY')
-				);
+				config.data.labels.push(newDateString(config.data.labels.length));
 
 				for (var index = 0; index < config.data.datasets.length; ++index) {
 					config.data.datasets[index].data.push(randomScalingFactor());

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -208,8 +208,10 @@
 			Chart.layoutService.update(this, this.chart.width, this.chart.height);
 		},
 
-		buildOrUpdateControllers: function buildOrUpdateControllers(resetNewControllers) {
+		buildOrUpdateControllers: function buildOrUpdateControllers() {
 			var types = [];
+			var newControllers = [];
+
 			helpers.each(this.data.datasets, function(dataset, datasetIndex) {
 				if (!dataset.type) {
 					dataset.type = this.config.type;
@@ -222,10 +224,7 @@
 					dataset.controller.updateIndex(datasetIndex);
 				} else {
 					dataset.controller = new Chart.controllers[type](this, datasetIndex);
-
-					if (resetNewControllers) {
-						dataset.controller.reset();
-					}
+					newControllers.push(dataset.controller);
 				}
 			}, this);
 
@@ -237,6 +236,8 @@
 					}
 				}
 			}
+
+			return newControllers;
 		},
 
 		resetElements: function resetElements() {
@@ -250,9 +251,14 @@
 			this.tooltip._data = this.data;
 
 			// Make sure dataset controllers are updated and new controllers are reset
-			this.buildOrUpdateControllers(true);
+			var newControllers = this.buildOrUpdateControllers();
 
 			Chart.layoutService.update(this, this.chart.width, this.chart.height);
+
+			// Can only reset the new controllers after the scales have been updated
+			helpers.each(newControllers, function(controller) {
+				controller.reset();
+			});
 
 			// Make sure all dataset controllers have correct meta data counts
 			helpers.each(this.data.datasets, function(dataset, datasetIndex) {


### PR DESCRIPTION
Changed `buildOrUpdateControllers` so that it returns an array of the newly created controllers. Removed the parameter to reset new controllers since it was unused.

New controllers are built before scales are updated so that #1725 is not broken but controllers are not reset until after the scales have been updated so that we can safely use the `labelMoments` array in the time scale. 

Tested with the time scale sample files. Recreated the test case from #1725 and ensured that this did not break that fix.