### PR TITLE
Time scale updates to remove unnecessary extra ticks

### DIFF
--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -54,7 +54,7 @@
 
 			// defaults to unit's corresponding unitFormat below or override using pattern string from http://momentjs.com/docs/#/displaying/format/
 			displayFormats: {
-				'millisecond': 'SSS [ms]',
+				'millisecond': 'h:mm:ss.SSS a', // 11:20:01.123 AM,
 				'second': 'h:mm:ss a', // 11:20:01 AM
 				'minute': 'h:mm:ss a', // 11:20:01 AM
 				'hour': 'MMM D, hA', // Sept 4, 5PM
@@ -143,7 +143,7 @@
 				// Determine the smallest needed unit of the time
 				var innerWidth = this.isHorizontal() ? this.width - (this.paddingLeft + this.paddingRight) : this.height - (this.paddingTop + this.paddingBottom);
 				var labelCapacity = innerWidth / (this.options.ticks.fontSize + 10);
-				var buffer = this.options.time.round ? 0 : 2;
+				var buffer = this.options.time.round ? 0 : 1;
 
 				// Start as small as possible
 				this.tickUnit = 'millisecond';
@@ -225,7 +225,7 @@
 			// Always show the right tick
 			if (this.options.time.max) {
 				this.ticks.push(this.lastTick.clone());
-			} else {
+			} else if (this.ticks[this.ticks.length - 1].diff(this.lastTick, this.tickUnit, true) !== 0) {
 				this.tickRange = Math.ceil(this.tickRange / this.unitScale) * this.unitScale;
 				this.ticks.push(this.firstTick.clone().add(this.tickRange, this.tickUnit));
 				this.lastTick = this.ticks[this.ticks.length - 1].clone();

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -217,8 +217,15 @@
 
 			// For every unit in between the first and last moment, create a moment and add it to the ticks tick
 			for (var i = 1; i < this.tickRange; ++i) {
+				var newTick = roundedStart.clone().add(i, this.tickUnit);
+
+				// Are we greater than the max time
+				if (this.options.time.max && newTick.diff(this.lastTick, this.tickUnit, true) >= 0) {
+					break;
+				}
+
 				if (i % this.unitScale === 0) {
-					this.ticks.push(roundedStart.clone().add(i, this.tickUnit));
+					this.ticks.push(newTick);
 				}
 			}
 

--- a/test/scale.time.tests.js
+++ b/test/scale.time.tests.js
@@ -55,7 +55,7 @@ describe('Time scale tests', function() {
 				round: false,
 				displayFormat: false,
 				displayFormats: {
-					'millisecond': 'SSS [ms]',
+					'millisecond': 'h:mm:ss.SSS a', // 11:20:01.123 AM
 					'second': 'h:mm:ss a', // 11:20:01 AM
 					'minute': 'h:mm:ss a', // 11:20:01 AM
 					'hour': 'MMM D, hA', // Sept 4, 5PM
@@ -122,7 +122,7 @@ describe('Time scale tests', function() {
 		scale.update(400, 50);
 
 		// Counts down because the lines are drawn top to bottom
-		expect(scale.ticks).toEqual(['Jan 1, 2015', 'Jan 3, 2015', 'Jan 5, 2015', 'Jan 7, 2015', 'Jan 9, 2015', 'Jan 11, 2015', 'Jan 13, 2015']);
+		expect(scale.ticks).toEqual(['Jan 1, 2015', 'Jan 3, 2015', 'Jan 5, 2015', 'Jan 7, 2015', 'Jan 9, 2015', 'Jan 11, 2015']);
 	});
 
 	it('should build ticks when the data is xy points', function() {
@@ -173,7 +173,7 @@ describe('Time scale tests', function() {
 		scale.update(400, 50);
 
 		// Counts down because the lines are drawn top to bottom
-		expect(scale.ticks).toEqual(['Jan 1, 2015', 'Jan 3, 2015', 'Jan 5, 2015', 'Jan 7, 2015', 'Jan 9, 2015', 'Jan 11, 2015', 'Jan 13, 2015']);
+		expect(scale.ticks).toEqual(['Jan 1, 2015', 'Jan 3, 2015', 'Jan 5, 2015', 'Jan 7, 2015', 'Jan 9, 2015', 'Jan 11, 2015']);
 	});
 
 	it('should build ticks using the config unit', function() {
@@ -224,6 +224,8 @@ describe('Time scale tests', function() {
 
 		//scale.buildTicks();
 		scale.update(400, 50);
+
+		// last date is feb 15 because we round to start of week
 		expect(scale.ticks).toEqual(['Dec 28, 2014', 'Jan 4, 2015', 'Jan 11, 2015', 'Jan 18, 2015', 'Jan 25, 2015', 'Feb 1, 2015', 'Feb 8, 2015', 'Feb 15, 2015']);
 	});
 


### PR DESCRIPTION
Also updated the millisecond time format to fix #1941 

## Old behaviour
![old time scale behaviour](https://cloud.githubusercontent.com/assets/6757853/12698693/5d9f85d0-c771-11e5-9c87-3aacbd65133f.png)

## New Behaviour
![time scale new behaviour](https://cloud.githubusercontent.com/assets/6757853/12698718/1bc74f70-c772-11e5-9f14-8722ce38c617.png)
