### PR TITLE
When the last label would overlap with the previously shown label, skip the previously shown one

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -484,7 +484,9 @@ module.exports = function(Chart) {
 					helpers.each(this.ticks, function(label, index) {
 						// Blank ticks
 						var isLastTick = this.ticks.length === index + 1;
-						var shouldSkip = skipRatio > 1 && index % skipRatio > 0;
+
+						// Since we always show the last tick,we need may need to hide the last shown one before
+						var shouldSkip = (skipRatio > 1 && index % skipRatio > 0) || (index % skipRatio === 0 && index + skipRatio > this.ticks.length);
 						if (shouldSkip && !isLastTick || (label === undefined || label === null)) {
 							return;
 						}


### PR DESCRIPTION
Fixes #1884 

## Old Behaviour
![old small](https://cloud.githubusercontent.com/assets/6757853/13053217/4cba2a9c-d3d1-11e5-8d05-0fc855b332b7.png)


## New Behaviour
![new label](https://cloud.githubusercontent.com/assets/6757853/13053219/50185ca4-d3d1-11e5-8d26-2b662e2b6aa8.png)
