### PR TITLE
Fix stacking, tooltip, and legend order for stackables

### DIFF
--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -205,7 +205,7 @@ module.exports = function(Chart) {
 				var sumPos = 0,
 					sumNeg = 0;
 
-				for (var i = this.chart.data.datasets.length - 1; i > datasetIndex; i--) {
+				for (var i = 0; i < datasetIndex; i++) {
 					var ds = this.chart.data.datasets[i];
 					if (ds.type === 'line' && helpers.isDatasetVisible(ds)) {
 						if (ds.data[index] < 0) {

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -314,7 +314,7 @@ module.exports = function(Chart) {
 				if (helpers.isDatasetVisible(dataset)) {
 					dataset.controller.draw(ease);
 				}
-			});
+			}, null, true);
 
 			// Finally draw the tooltip
 			this.tooltip.transition(easingDecimal).draw();

--- a/src/core/core.legend.js
+++ b/src/core/core.legend.js
@@ -9,6 +9,7 @@ module.exports = function(Chart) {
 		display: true,
 		position: 'top',
 		fullWidth: true, // marks that this box should take the full width of the canvas (pushing down other boxes)
+		reverse: false,
 
 		// a callback that will handle
 		onClick: function(e, legendItem) {
@@ -143,6 +144,9 @@ module.exports = function(Chart) {
 		beforeBuildLabels: helpers.noop,
 		buildLabels: function() {
 			this.legendItems = this.options.labels.generateLabels.call(this, this.chart.data);
+			if(this.options.reverse){
+				this.legendItems.reverse();
+			}
 		},
 		afterBuildLabels: helpers.noop,
 

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -253,7 +253,7 @@ module.exports = function(Chart) {
 								datasetIndex: datasetIndex
 							});
 						}
-					});
+					}, null, element._yScale.options.stacked);
 
 					helpers.each(this._active, function(active) {
 						if (active) {
@@ -262,7 +262,7 @@ module.exports = function(Chart) {
 								backgroundColor: active._view.backgroundColor
 							});
 						}
-					});
+					}, null, element._yScale.options.stacked);
 
 					tooltipPosition = this.getAveragePosition(this._active);
 					tooltipPosition.y = this._active[0]._yScale.getPixelForDecimal(0.5);

--- a/test/controller.line.tests.js
+++ b/test/controller.line.tests.js
@@ -655,7 +655,9 @@ describe('Line controller tests', function() {
 		};
 
 		var controller = new Chart.controllers.line(chart, 0);
+		var controller2 = new Chart.controllers.line(chart, 1);
 		controller.update();
+		controller2.update();
 
 		// Line element
 		expect(chart.data.datasets[0].metaDataset._model).toEqual(jasmine.objectContaining({
@@ -667,13 +669,13 @@ describe('Line controller tests', function() {
 		expect(chart.data.datasets[0].metaData[0]._model).toEqual(jasmine.objectContaining({
 			// Point
 			x: 91,
-			y: 30,
+			y: 77,
 		}));
 
 		expect(chart.data.datasets[0].metaData[1]._model).toEqual(jasmine.objectContaining({
 			// Point
 			x: 141,
-			y: 18,
+			y: 65,
 		}));
 
 		expect(chart.data.datasets[0].metaData[2]._model).toEqual(jasmine.objectContaining({
@@ -685,8 +687,34 @@ describe('Line controller tests', function() {
 		expect(chart.data.datasets[0].metaData[3]._model).toEqual(jasmine.objectContaining({
 			// Point
 			x: 242,
+			y: 109,
+		}));
+
+		expect(chart.data.datasets[1].metaData[0]._model).toEqual(jasmine.objectContaining({
+			// Point
+			x: 91,
+			y: 30,
+		}));
+
+		expect(chart.data.datasets[1].metaData[1]._model).toEqual(jasmine.objectContaining({
+			// Point
+			x: 141,
+			y: 18,
+		}));
+
+		expect(chart.data.datasets[1].metaData[2]._model).toEqual(jasmine.objectContaining({
+			// Point
+			x: 192,
+			y: 30,
+		}));
+
+		expect(chart.data.datasets[1].metaData[3]._model).toEqual(jasmine.objectContaining({
+			// Point
+			x: 242,
 			y: 180,
 		}));
+
+
 	});
 
 	it('should find the correct scale zero when the data is all positive', function() {

--- a/test/core.legend.tests.js
+++ b/test/core.legend.tests.js
@@ -11,6 +11,7 @@ describe('Legend block tests', function() {
 			display: true,
 			position: 'top',
 			fullWidth: true, // marks that this box should take the full width of the canvas (pushing down other boxes)
+			reverse: false,
 
 			// a callback that will handle
 			onClick: jasmine.any(Function),


### PR DESCRIPTION
Stacked line and bar charts now behave predictably with the first
dataset on the bottom stacked upwards.

Legends can now be reversed with the `reversed: true` property.

Tooltips detect the stacked scale property now, reversing when
appropriate