### PR TITLE
A fix for nnnick/Chart.js#2086 

### DIFF
--- a/docs/01-Scales.md
+++ b/docs/01-Scales.md
@@ -168,7 +168,7 @@ The time scale extends the core scale class with the following tick template:
 	position: "bottom",
 	time: {
 		// string/callback - By default, date objects are expected. You may use a pattern string from http://momentjs.com/docs/#/parsing/string-format/ to parse a time string format, or use a callback function that is passed the label, and must return a moment() instance.
-		format: false,
+		parser: false,
 		// string - By default, unit will automatically be detected.  Override with 'week', 'month', 'year', etc. (see supported time measurements)
 		unit: false,
 		// string - By default, no rounding is applied.  To round, set to a supported time unit eg. 'week', 'month', 'year', etc.

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -48,7 +48,8 @@ module.exports = function(Chart) {
 		position: "bottom",
 
 		time: {
-			format: false, // false == date objects or use pattern string from http://momentjs.com/docs/#/parsing/string-format/
+			parser: false, // false == a pattern string from http://momentjs.com/docs/#/parsing/string-format/ or a custom callback that converts its argument to a moment
+			format: false, // DEPRECATED false == date objects, moment object, callback or a pattern string from http://momentjs.com/docs/#/parsing/string-format/
 			unit: false, // false == automatic or override with week, month, year, etc.
 			round: false, // none, or override with week, month, year, etc.
 			displayFormat: false, // DEPRECATED
@@ -293,6 +294,12 @@ module.exports = function(Chart) {
 			}
 		},
 		parseTime: function(label) {
+			if (typeof this.options.time.parser === 'string') {
+				return moment(label, this.options.time.parser)
+			}
+			if (typeof this.options.time.parser === 'function') {
+				return this.options.time.parser(label);
+			}
 			// Date objects
 			if (typeof label.getMonth === 'function' || typeof label === 'number') {
 				return moment(label);
@@ -303,6 +310,7 @@ module.exports = function(Chart) {
 			}
 			// Custom parsing (return an instance of moment)
 			if (typeof this.options.time.format !== 'string' && this.options.time.format.call) {
+				console.warn("options.time.format is deprecated and replaced by options.time.parser. See http://nnnick.github.io/Chart.js/docs-v2/#scales-time-scale");
 				return this.options.time.format(label);
 			}
 			// Moment format parsing

--- a/src/scales/scale.time.js
+++ b/src/scales/scale.time.js
@@ -295,7 +295,7 @@ module.exports = function(Chart) {
 		},
 		parseTime: function(label) {
 			if (typeof this.options.time.parser === 'string') {
-				return moment(label, this.options.time.parser)
+				return moment(label, this.options.time.parser);
 			}
 			if (typeof this.options.time.parser === 'function') {
 				return this.options.time.parser(label);

--- a/test/scale.time.tests.js
+++ b/test/scale.time.tests.js
@@ -42,6 +42,7 @@ describe('Time scale tests', function() {
 				autoSkipPadding: 20
 			},
 			time: {
+				parser: false,
 				format: false,
 				unit: false,
 				round: false,
@@ -166,6 +167,43 @@ describe('Time scale tests', function() {
 
 		// Counts down because the lines are drawn top to bottom
 		expect(scale.ticks).toEqual(['Jan 1, 2015', 'Jan 3, 2015', 'Jan 5, 2015', 'Jan 7, 2015', 'Jan 9, 2015', 'Jan 11, 2015']);
+	});
+
+	it('should allow custom time parsers', function() {
+		// Helper to build date objects
+
+
+		var scaleID = 'myScale';
+		var mockData = {
+			datasets: [{
+				data: [{
+					x: 375058800,
+					y: 1
+				}],
+			}]
+		};
+		var verticalScaleConfig = Chart.helpers.clone(Chart.scaleService.getScaleDefaults('time'));
+		verticalScaleConfig.time.unit = 'day';
+		verticalScaleConfig.time.round = true;
+		verticalScaleConfig.time.parser = function customTimeParser(label) {
+			console.log("got "+label+" returning "+moment.unix(label))
+			return moment.unix(label);
+		}
+
+		var mockContext = window.createMockContext();
+		var Constructor = Chart.scaleService.getScaleConstructor('time');
+		var scale = new Constructor({
+			ctx: mockContext,
+			options: verticalScaleConfig,
+			chart: {
+				data: mockData
+			},
+			id: scaleID
+		});
+		scale.update(400, 50);
+
+		// Counts down because the lines are drawn top to bottom
+		expect(scale.ticks).toEqual(['Nov 20, 1981', 'Nov 20, 1981']);
 	});
 
 	it('should build ticks using the config unit', function() {

--- a/test/scale.time.tests.js
+++ b/test/scale.time.tests.js
@@ -177,7 +177,7 @@ describe('Time scale tests', function() {
 		var mockData = {
 			datasets: [{
 				data: [{
-					x: 375058800,
+					x: 375068900,
 					y: 1
 				}],
 			}]
@@ -186,7 +186,6 @@ describe('Time scale tests', function() {
 		verticalScaleConfig.time.unit = 'day';
 		verticalScaleConfig.time.round = true;
 		verticalScaleConfig.time.parser = function customTimeParser(label) {
-			console.log("got "+label+" returning "+moment.unix(label))
 			return moment.unix(label);
 		}
 


### PR DESCRIPTION
Adds a time.parser option that is essentially time.format but is processed with higher priority. Deprecates time.format (which was confusingly named anyway). Fixes nnnick/Chart.js#2086 