### PR TITLE
Tooltip fix

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -1683,7 +1683,7 @@
 		},
 		calculateY : function(value){
 			var scalingFactor = this.drawingArea() / (this.min - this.max);
-			return this.endPoint - (scalingFactor * (value - this.min));
+			return Math.round(this.endPoint - (scalingFactor * (value - this.min)));
 		},
 		calculateX : function(index){
 			var isRotated = (this.xLabelRotation > 0),


### PR DESCRIPTION
In [this](https://jsfiddle.net/1g2waLa2/8/) example tooltip is appears when mouse is over the January bar. In the [other](https://jsfiddle.net/1g2waLa2/7/) example tooltip is not appeared. The difference is that in the second case January data is set to 0. I have tried to solve this and found that problem is that cursor position is always integer value.