### PR TITLE
Expose yAlign and xAlign as a tooltip option

### DIFF
--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -90,6 +90,8 @@ module.exports = function(Chart) {
 					// Positioning
 					xPadding: options.tooltips.xPadding,
 					yPadding: options.tooltips.yPadding,
+					xAlign : options.tooltips.yAlign,
+					yAlign : options.tooltips.xAlign,
 
 					// Body
 					bodyColor: options.tooltips.bodyColor,
@@ -118,8 +120,6 @@ module.exports = function(Chart) {
 					footerMarginTop: options.tooltips.footerMarginTop,
 
 					// Appearance
-					yAlign : options.tooltips.yAlign,
-					xAlign : options.tooltips.xAlign,
 					caretSize: options.tooltips.caretSize,
 					cornerRadius: options.tooltips.cornerRadius,
 					backgroundColor: options.tooltips.backgroundColor,

--- a/src/core/core.tooltip.js
+++ b/src/core/core.tooltip.js
@@ -24,6 +24,8 @@ module.exports = function(Chart) {
 		footerAlign: "left",
 		yPadding: 6,
 		xPadding: 6,
+		yAlign : 'center',
+		xAlign : 'center',
 		caretSize: 5,
 		cornerRadius: 6,
 		multiKeyBackground: '#fff',
@@ -116,6 +118,8 @@ module.exports = function(Chart) {
 					footerMarginTop: options.tooltips.footerMarginTop,
 
 					// Appearance
+					yAlign : options.tooltips.yAlign,
+					xAlign : options.tooltips.xAlign,
 					caretSize: options.tooltips.caretSize,
 					cornerRadius: options.tooltips.cornerRadius,
 					backgroundColor: options.tooltips.backgroundColor,
@@ -333,8 +337,6 @@ module.exports = function(Chart) {
 			return size;
 		},
 		determineAlignment: function determineAlignment(size) {
-			this._model.xAlign = this._model.yAlign = "center";
-
 			if (this._model.y < size.height) {
 				this._model.yAlign = 'top';
 			} else if (this._model.y > (this._chart.height - size.height)) {


### PR DESCRIPTION
This change allows for specifying the preferred alignment of the tooltip, defaults for xAlign and yAlign are still 'center'.