### PR TITLE
Fix multi-dataset bar highlighting

### DIFF
--- a/src/Chart.Bar.js
+++ b/src/Chart.Bar.js
@@ -83,8 +83,10 @@
 						bar.restore(['fillColor', 'strokeColor']);
 					});
 					helpers.each(activeBars, function(activeBar){
-						activeBar.fillColor = activeBar.highlightFill;
-						activeBar.strokeColor = activeBar.highlightStroke;
+						if (activeBar) {
+							activeBar.fillColor = activeBar.highlightFill;
+							activeBar.strokeColor = activeBar.highlightStroke;
+						}
 					});
 					this.showTooltip(activeBars);
 				});


### PR DESCRIPTION
When a bar graph contains multiple data sets and any of the datasets are incomplete (ie: no data yet for April through December of this year), the `activeBar` objects without a data point at that location received by `this.getBarsAtEvent(evt)` are `undefined`. This includes a check prior to attempting to access its properties (lines 86-89).