### PR TITLE
Fixed a bug with calculating the canvas width and height

### DIFF
--- a/src/Chart.Core.js
+++ b/src/Chart.Core.js
@@ -40,8 +40,6 @@
 		var width = this.width = computeDimension(context.canvas,'Width') || context.canvas.width;
 		var height = this.height = computeDimension(context.canvas,'Height') || context.canvas.height;
 
-		width = this.width = context.canvas.width;
-		height = this.height = context.canvas.height;
 		this.aspectRatio = this.width / this.height;
 		//High pixel density displays - multiply the size of the canvas height/width by the device pixel ratio, then scale.
 		helpers.retinaScale(this);


### PR DESCRIPTION
A previous commit (https://github.com/nnnick/Chart.js/pull/1771) removing a workaround for an old Firefox bug left part
of that workaround in, and it was preventing the expected behavior of
the canvas size being equal to the offsetWidth and offsetHeight of the
canvas prior to instantiation of Chart.JS.

This is a fix for Issue https://github.com/nnnick/Chart.js/issues/2205