### PR TITLE
Fix "main" file path in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/nnnick/Chart.js",
   "author": "nnnick",
   "main": [
-    "Chart.js"
+    "dist/Chart.js"
   ],
   "devDependencies": {
     "jquery": "~2.1.4"


### PR DESCRIPTION
This updates the `"main"` path in bower.json to include the `dist` directory where the main `Chart.js` file lives.

Related issue here: https://github.com/nnnick/Chart.js/issues/2236