### PR TITLE
Add rotation and circumference properties to doughnut/pie charts

### DIFF
--- a/src/elements/element.arc.js
+++ b/src/elements/element.arc.js
@@ -30,9 +30,18 @@ module.exports = function(Chart, moment) {
           y: chartY
         });
 
-        // Put into the range of (-PI/2, 3PI/2]
-        var startAngle = vm.startAngle < (-0.5 * Math.PI) ? vm.startAngle + (2.0 * Math.PI) : vm.startAngle > (1.5 * Math.PI) ? vm.startAngle - (2.0 * Math.PI) : vm.startAngle;
-        var endAngle = vm.endAngle < (-0.5 * Math.PI) ? vm.endAngle + (2.0 * Math.PI) : vm.endAngle > (1.5 * Math.PI) ? vm.endAngle - (2.0 * Math.PI) : vm.endAngle;
+        //Sanitise angle range
+        var startAngle = vm.startAngle;
+        var endAngle = vm.endAngle;
+        while (endAngle < startAngle) {
+          endAngle += 2.0 * Math.PI;
+        }
+        while (pointRelativePosition.angle > endAngle) {
+          pointRelativePosition.angle -= 2.0 * Math.PI;
+        }
+        while (pointRelativePosition.angle < startAngle) {
+          pointRelativePosition.angle += 2.0 * Math.PI;
+        }
 
         //Check if within the range of the open/close angle
         var betweenAngles = (pointRelativePosition.angle >= startAngle && pointRelativePosition.angle <= endAngle),


### PR DESCRIPTION
Added two new properties to doughnut/pie charts:
 - `rotation` - specify the angle where the first arc starts
 - `circumference` - specify the total circumference angle of the chart

The arc element's `inRange` function had to be modified to fix tooltip support.

The chart's `outerRadius` value is adjusted to ensure the chart is filling all available chart area (and is offset to ensure it is centered). This is done by somewhat complex code that determines the chart's width/height assuming a radius of 1.0, and calculating a scaled `outerRadius` from the size. This should work for all combinations of `rotation`/`circumference`, including non right-angles.

![screen shot 2016-04-17 at 12 37 54 am](https://cloud.githubusercontent.com/assets/1538523/14581621/aeaabe86-0434-11e6-9a47-ba103427149f.png)
![screen shot 2016-04-17 at 12 39 04 am](https://cloud.githubusercontent.com/assets/1538523/14581627/d4ad96a8-0434-11e6-8f98-2eb0a3fa7a3b.png)
![screen shot 2016-04-17 at 12 40 41 am](https://cloud.githubusercontent.com/assets/1538523/14581638/0f6795b4-0435-11e6-897d-0934c385f544.png)
