### PR TITLE
Split Doughnut/Pie example usage into two code blocks

### DIFF
--- a/docs/06-Pie-Doughnut-Chart.md
+++ b/docs/06-Pie-Doughnut-Chart.md
@@ -24,15 +24,17 @@ They are also registered under two aliases in the `Chart` core. Other than their
 
 ```javascript
 // For a pie chart
-var myPieChart = new Chart(ctx[0],{
-	type:'pie',
+var myPieChart = new Chart(ctx,{
+	type: 'pie',
 	data: data,
 	options: options
 });
+```
 
+```javascript
 // And for a doughnut chart
-var myDoughnutChart = new Chart(ctx[1], {
-	type:'doughnut',
+var myDoughnutChart = new Chart(ctx, {
+	type: 'doughnut',
 	data: data,
 	options: options
 });


### PR DESCRIPTION
Simple change, but makes running that code a lot more straightforward in the documentation, now that sharing the same data object isn't possible in 2.0.