### PR TITLE
Fix typo in plugin 'destroy'

### DIFF
--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -422,7 +422,7 @@ module.exports = function(Chart) {
 			canvas.style.width = this.chart.originalCanvasStyleWidth;
 			canvas.style.height = this.chart.originalCanvasStyleHeight;
 
-			Chart.pluginService.notifyPlugins('destory', [this]);
+			Chart.pluginService.notifyPlugins('destroy', [this]);
 
 			delete Chart.instances[this.id];
 		},

--- a/src/core/core.plugin.js
+++ b/src/core/core.plugin.js
@@ -53,6 +53,6 @@ module.exports = function(Chart) {
 		afterDraw: helpers.noop,
 
 		// Called during destroy
-		destory: helpers.noop,
+		destroy: helpers.noop,
 	});
 };


### PR DESCRIPTION
`destory` event was triggered instead of `destroy`