### PR TITLE
Documentation tweaks for 2.0 relase

### DIFF
--- a/docs/02-Line-Chart.md
+++ b/docs/02-Line-Chart.md
@@ -44,10 +44,10 @@ var data = {
 			lineTension: 0.1,
 
 			// String - the color to fill the area under the line with if fill is true
-			backgroundColor: "rgba(220,220,220,0.2)",
+			backgroundColor: "rgba(75,192,192,0.4)",
 
 			// String - Line color
-			borderColor: "rgba(220,220,220,1)",
+			borderColor: "rgba(75,192,192,1)",
 
 			// String - cap style of the line. See https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineCap
 			borderCapStyle: 'butt',
@@ -64,7 +64,7 @@ var data = {
 			// The properties below allow an array to be specified to change the value of the item at the given index
 
 			// String or Array - Point stroke color
-			pointBorderColor: "rgba(220,220,220,1)",
+			pointBorderColor: "rgba(75,192,192,1)",
 
 			// String or Array - Point fill color
 			pointBackgroundColor: "#fff",
@@ -76,7 +76,7 @@ var data = {
 			pointHoverRadius: 5,
 
 			// String or Array - point background color when hovered
-			pointHoverBackgroundColor: "rgba(220,220,220,1)",
+			pointHoverBackgroundColor: "rgba(75,192,192,1)",
 
 			// String or Array - Point border color when hovered
 			pointHoverBorderColor: "rgba(220,220,220,1)",
@@ -102,14 +102,14 @@ var data = {
 		{
 			label: "My Second dataset",
 			fill: false,
-			backgroundColor: "rgba(220,220,220,0.2)",
-			borderColor: "rgba(220,220,220,1)",
-			pointBorderColor: "rgba(220,220,220,1)",
+			backgroundColor: "rgba(255,205,86,0.4)",
+			borderColor: "rgba(255,205,86,1)",
+			pointBorderColor: "rgba(255,205,86,1)",
 			pointBackgroundColor: "#fff",
 			pointBorderWidth: 1,
 			pointHoverRadius: 5,
-			pointHoverBackgroundColor: "rgba(220,220,220,1)",
-			pointHoverBorderColor: "rgba(220,220,220,1)",
+			pointHoverBackgroundColor: "rgba(255,205,86,1)",
+			pointHoverBorderColor: "rgba(255,205,86,1)",
 			pointHoverBorderWidth: 2,
 			data: [28, 48, 40, 19, 86, 27, 90]
 		}

--- a/docs/03-Bar-Chart.md
+++ b/docs/03-Bar-Chart.md
@@ -32,19 +32,19 @@ var data = {
 
 			// The properties below allow an array to be specified to change the value of the item at the given index
 			// String  or array - the bar color
-			backgroundColor: "rgba(220,220,220,0.2)",
+			backgroundColor: "rgba(255,99,132,0.2)",
 
 			// String or array - bar stroke color
-			borderColor: "rgba(220,220,220,1)",
+			borderColor: "rgba(255,99,132,1)",
 
 			// Number or array - bar border width
 			borderWidth: 1,
 
 			// String or array - fill color when hovered
-			hoverBackgroundColor: "rgba(220,220,220,0.2)",
+			hoverBackgroundColor: "rgba(255,99,132,0.4)",
 
 			// String or array - border color when hovered
-			hoverBorderColor: "rgba(220,220,220,1)",
+			hoverBorderColor: "rgba(255,99,132,1)",
 
 			// The actual data
 			data: [65, 59, 80, 81, 56, 55, 40],
@@ -54,11 +54,11 @@ var data = {
 		},
 		{
 			label: "My Second dataset",
-			backgroundColor: "rgba(220,220,220,0.2)",
-			borderColor: "rgba(220,220,220,1)",
+			backgroundColor: "rgba(54,162,235,0.2)",
+			borderColor: "rgba(54,162,235,1)",
 			borderWidth: 1,
-			hoverBackgroundColor: "rgba(220,220,220,0.2)",
-			hoverBorderColor: "rgba(220,220,220,1)",
+			hoverBackgroundColor: "rgba(54,162,235,0.4)",
+			hoverBorderColor: "rgba(54,162,235,1)",
 			data: [28, 48, 40, 19, 86, 27, 90]
 		}
 	]

--- a/docs/04-Radar-Chart.md
+++ b/docs/04-Radar-Chart.md
@@ -29,22 +29,22 @@ var data = {
 	datasets: [
 		{
 			label: "My First dataset",
-			backgroundColor: "rgba(220,220,220,0.2)",
-			borderColor: "rgba(220,220,220,1)",
-			pointBackgroundColor: "rgba(220,220,220,1)",
+			backgroundColor: "rgba(179,181,198,0.2)",
+			borderColor: "rgba(179,181,198,1)",
+			pointBackgroundColor: "rgba(179,181,198,1)",
 			pointBorderColor: "#fff",
 			pointHoverBackgroundColor: "#fff",
-			pointHoverBorderColor: "rgba(220,220,220,1)",
+			pointHoverBorderColor: "rgba(179,181,198,1)",
 			data: [65, 59, 90, 81, 56, 55, 40]
 		},
 		{
 			label: "My Second dataset",
-			backgroundColor: "rgba(151,187,205,0.2)",
-			borderColor: "rgba(151,187,205,1)",
-			pointBackgroundColor: "rgba(151,187,205,1)",
+			backgroundColor: "rgba(255,99,132,0.2)",
+			borderColor: "rgba(255,99,132,1)",
+			pointBackgroundColor: "rgba(255,99,132,1)",
 			pointBorderColor: "#fff",
 			pointHoverBackgroundColor: "#fff",
-			pointHoverBorderColor: "rgba(151,187,205,1)",
+			pointHoverBorderColor: "rgba(255,99,132,1)",
 			data: [28, 48, 40, 19, 96, 27, 100]
 		}
 	]

--- a/docs/05-Polar-Area-Chart.md
+++ b/docs/05-Polar-Area-Chart.md
@@ -27,18 +27,18 @@ new Chart(ctx, {
 var data = {
 	datasets: [{
 		data: [
-			10,
-			32,
-			53,
-			14,
-			22,
+			11,
+			16,
+			7,
+			3,
+			14
 		],
 		backgroundColor: [
-			"#F7464A",
-			"#46BFBD",
-			"#FDB45C",
-			"#949FB1",
-			"#4D5360",
+			"#FF6384",
+			"#4BC0C0",
+			"#FFCE56",
+			"#E7E9ED",
+			"#36A2EB"
 		],
 		label: 'My dataset' // for legend
 	}],
@@ -47,7 +47,7 @@ var data = {
 		"Green",
 		"Yellow",
 		"Grey",
-		"Dark Grey"
+		"Blue"
 	]
 };
 ```

--- a/docs/06-Pie-Doughnut-Chart.md
+++ b/docs/06-Pie-Doughnut-Chart.md
@@ -53,14 +53,14 @@ var data = {
         {
             data: [300, 50, 100],
             backgroundColor: [
-                "#F7464A",
-                "#46BFBD",
-                "#FDB45C"
+                "#FF6384",
+                "#36A2EB",
+                "#FFCE56"
             ],
             hoverBackgroundColor: [
-                "#FF5A5E",
-                "#5AD3D1",
-                "#FFC870"
+                "#FF6384",
+                "#36A2EB",
+                "#FFCE56"
             ]
         }]
 };

--- a/docs/08-Notes.md
+++ b/docs/08-Notes.md
@@ -4,25 +4,11 @@ anchor: notes
 ---
 
 ### Browser support
-Browser support for the canvas element is available in all modern & major mobile browsers <a href="http://caniuse.com/canvas" target="_blank">(caniuse.com/canvas)</a>.
 
-For IE8 & below, I would recommend using the polyfill ExplorerCanvas - available at <a href="https://code.google.com/p/explorercanvas/" target="_blank">https://code.google.com/p/explorercanvas/</a>. It falls back to Internet explorer's format VML when canvas support is not available. Example use:
+Chart.js offers support for all browsers where canvas is supported.
 
-```html
-<head>
-	<!--[if lte IE 8]>
-		<script src="excanvas.js"></script>
-	<![endif]-->
-</head>
-```
+Browser support for the canvas element is available in all modern & major mobile browsers <a href="http://http://caniuse.com/#feat=canvas" target="_blank">(http://caniuse.com/#feat=canvas)</a>.
 
-Usually I would recommend feature detection to choose whether or not to load a polyfill, rather than IE conditional comments, however in this case, VML is a Microsoft proprietary format, so it will only work in IE.
-
-Some important points to note in my experience using ExplorerCanvas as a fallback.
-
-- Initialise charts on load rather than DOMContentReady when using the library, as sometimes a race condition will occur, and it will result in an error when trying to get the 2d context of a canvas.
-- New VML DOM elements are being created for each animation frame and there is no hardware acceleration. As a result animation is usually slow and jerky, with flashing text. It is a good idea to dynamically turn off animation based on canvas support. I recommend using the excellent <a href="http://modernizr.com/" target="_blank">Modernizr</a> to do this.
-- When declaring fonts, the library explorercanvas requires the font name to be in single quotes inside the string. For example, instead of your scaleFontFamily property being simply "Arial", explorercanvas support, use "'Arial'" instead. Chart.js does this for default values.
 
 ### Bugs & issues
 


### PR DESCRIPTION
This change covers some small updates to colours and values for the site to render the examples in the documentation.

It also updates the browser support information, and removes the notice about supporting IE8 and below, where `Object.defineProperty` is not available.